### PR TITLE
Disallow custom string for planning group property in RViz Display

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_display.h
@@ -72,7 +72,7 @@ class StringProperty;
 class BoolProperty;
 class FloatProperty;
 class RosTopicProperty;
-class EditableEnumProperty;
+class EnumProperty;
 class ColorProperty;
 class MovableText;
 }  // namespace rviz
@@ -292,7 +292,7 @@ protected:
   rviz::Property* plan_category_;
   rviz::Property* metrics_category_;
 
-  rviz::EditableEnumProperty* planning_group_property_;
+  rviz::EnumProperty* planning_group_property_;
   rviz::BoolProperty* query_start_state_property_;
   rviz::BoolProperty* query_goal_state_property_;
   rviz::FloatProperty* query_marker_scale_property_;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -49,7 +49,7 @@
 #include <rviz/properties/bool_property.h>
 #include <rviz/properties/float_property.h>
 #include <rviz/properties/ros_topic_property.h>
-#include <rviz/properties/editable_enum_property.h>
+#include <rviz/properties/enum_property.h>
 #include <rviz/properties/color_property.h>
 #include <rviz/display_context.h>
 #include <rviz/frame_manager.h>
@@ -124,7 +124,7 @@ MotionPlanningDisplay::MotionPlanningDisplay()
   // Planning request category -----------------------------------------------------------------------------------------
 
   planning_group_property_ =
-      new rviz::EditableEnumProperty("Planning Group", "",
+      new rviz::EnumProperty("Planning Group", "",
                                      "The name of the group of links to plan for (from the ones defined in the SRDF)",
                                      plan_category_, SLOT(changedPlanningGroup()), this);
   show_workspace_property_ = new rviz::BoolProperty("Show Workspace", false,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -125,8 +125,8 @@ MotionPlanningDisplay::MotionPlanningDisplay()
 
   planning_group_property_ =
       new rviz::EnumProperty("Planning Group", "",
-                                     "The name of the group of links to plan for (from the ones defined in the SRDF)",
-                                     plan_category_, SLOT(changedPlanningGroup()), this);
+                             "The name of the group of links to plan for (from the ones defined in the SRDF)",
+                             plan_category_, SLOT(changedPlanningGroup()), this);
   show_workspace_property_ = new rviz::BoolProperty("Show Workspace", false,
                                                     "Shows the axis-aligned bounding box for "
                                                     "the workspace allowed for planning",


### PR DESCRIPTION
### Description
Hi, I am an undergad student working on my first PR to moveit. From the list of minor issues I found [here](https://github.com/ros-planning/moveit/issues/2741), I am working on the issue 14.

>In the RViz display, the property "Planning Group" under "Planning Request" allows to type in a custom string and goes blank if the string is not a valid group name. I'd propose to simply disallow custom strings here and turn it into a simple drop-down list

### Implementation Details for PR
The property "planning group" under "planning request" in the display menu under Motion Planning Plugin is of the type `rviz::EditableEnumProperty`, which lets us enter any custom string. I changed this type to `rviz::EnumProperty` and accordingly included appropriate header files in the required files.`

### Modified GUI 
Video [Link](https://drive.google.com/file/d/1V1IqmeQEHADaaB3NOp8XmVzU22a7i6vI/view?usp=sharing)


### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"