### PR TITLE
only collect links with geometry for restricted collision checking

### DIFF
--- a/moveit_core/collision_detection_fcl/src/collision_common.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_common.cpp
@@ -938,7 +938,7 @@ void cleanCollisionGeometryCache()
 void CollisionData::enableGroup(const moveit::core::RobotModelConstPtr& robot_model)
 {
   if (robot_model->hasJointModelGroup(req_->group_name))
-    active_components_only_ = &robot_model->getJointModelGroup(req_->group_name)->getUpdatedLinkModelsSet();
+    active_components_only_ = &robot_model->getJointModelGroup(req_->group_name)->getUpdatedLinkModelsWithGeometrySet();
   else
     active_components_only_ = nullptr;
 }


### PR DESCRIPTION
Assuming no unexpected bug this slightly reduces the size of the sets. This patch is for cleanup and I don't expect a performance gain.

@rhaschke I looked at this code after your comment [here](https://github.com/ros-planning/moveit_task_constructor/pull/428#issue-1589707550).