### PR TITLE
Backport: Differential Drive for Planar Joints from Moveit2

### DIFF
--- a/moveit_core/robot_model/CMakeLists.txt
+++ b/moveit_core/robot_model/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(${MOVEIT_LIB_NAME}
   )
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_profiler moveit_exceptions moveit_kinematics_base ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_utils moveit_profiler moveit_exceptions moveit_kinematics_base ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 if(CATKIN_ENABLE_TESTING)

--- a/moveit_core/robot_model/include/moveit/robot_model/planar_joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/planar_joint_model.h
@@ -46,6 +46,13 @@ namespace core
 class PlanarJointModel : public JointModel
 {
 public:
+  /** \brief different types of planar joints we support */
+  enum MotionModel
+  {
+    HOLONOMIC,  // default
+    DIFF_DRIVE
+  };
+
   PlanarJointModel(const std::string& name);
 
   void getVariableDefaultPositions(double* values, const Bounds& other_bounds) const override;
@@ -75,6 +82,26 @@ public:
     angular_distance_weight_ = weight;
   }
 
+  double getMinTranslationalDistance() const
+  {
+    return min_translational_distance_;
+  }
+
+  void setMinTranslationalDistance(double min_translational_distance)
+  {
+    min_translational_distance_ = min_translational_distance;
+  }
+
+  MotionModel getMotionModel() const
+  {
+    return motion_model_;
+  }
+
+  void setMotionModel(MotionModel model)
+  {
+    motion_model_ = model;
+  }
+
   /// Make the yaw component of a state's value vector be in the range [-Pi, Pi]. enforceBounds() also calls this
   /// function;
   /// Return true if a change is actually made
@@ -82,6 +109,24 @@ public:
 
 private:
   double angular_distance_weight_;
+  MotionModel motion_model_;
+  /// Only used for the differential drive motion model @see computeTurnDriveTurnGeometry
+  double min_translational_distance_;
 };
+/**
+ * @brief Compute the geometry to turn toward the target point, drive straight and then turn to target orientation
+ * @param[in]  from                       A vector representing the initial position [x0, y0, theta0]
+ * @param[in]  to                         A vector representing the target position  [x1, y1, theta1]
+ * @param[in]  min_translational_distance If the translational distance between \p from and \p to is less than this
+ *                                        value the motion will be pure rotation (meters)
+ * @param[out] dx                         x1 - x0 (meters)
+ * @param[out] dy                         y1 - y0 (meters)
+ * @param[out] initial_turn               The initial turn in radians to face the target
+ * @param[out] drive_angle                The orientation in radians that the robot will be driving straight at
+ * @param[out] final_turn                 The final turn in radians to the target orientation
+ */
+void computeTurnDriveTurnGeometry(const double* from, const double* to, const double min_translational_distance,
+                                  double& dx, double& dy, double& initial_turn, double& drive_angle,
+                                  double& final_turn);
 }  // namespace core
 }  // namespace moveit

--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -39,6 +39,8 @@
 
 #include <moveit/macros/class_forward.h>
 #include <moveit/exceptions/exceptions.h>
+#include <moveit/utils/lexical_casts.h>
+
 #include <urdf/model.h>
 #include <srdfdom/model.h>
 

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -978,26 +978,26 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
       }
     }
 
+    // parse a joint property string as a double with error handling
+    // if the property was successfully parsed,
+    // stores the resulting property value in prop_value and returns true
+    // otherwise logs a ROS_ERROR and returns false
+    auto parse_property_double = [&joint_name](auto& prop_name, auto& prop_value_str, double& prop_value) -> bool {
+      try
+      {
+        prop_value = moveit::core::toDouble(prop_value_str);
+        return true;
+      }
+      catch (const std::runtime_error& e)
+      {
+        ROS_ERROR_STREAM_NAMED(LOGNAME, "Unable to parse property " << prop_name << " for joint " << joint_name
+                                                                    << " as double: '" << prop_value_str << "'");
+      }
+      return false;
+    };
+
     for (const auto& [property_name, property_value_str] : srdf_model.getJointProperties(joint_name))
     {
-      // parse a joint property string as a double with error handling
-      // if the property was successfully parsed,
-      // stores the resulting property value in prop_value and returns true
-      // otherwise logs a ROS_ERROR and returns false
-      auto parse_property_double = [&joint_name](auto& prop_name, auto& prop_value_str, double& prop_value) -> bool {
-        try
-        {
-          prop_value = moveit::core::toDouble(prop_value_str);
-          return true;
-        }
-        catch (const std::runtime_error& e)
-        {
-          ROS_ERROR_STREAM_NAMED(LOGNAME, "Unable to parse property " << prop_name << " for joint " << joint_name
-                                                                      << " as double: '" << prop_value_str << "'");
-        }
-        return false;
-      };
-
       if (property_name == "angular_distance_weight")
       {
         double angular_distance_weight;

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -984,16 +984,16 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
       // if the property was successfully parsed,
       // stores the resulting property value in prop_value and returns true
       // otherwise logs a ROS_ERROR and returns false
-      auto parse_property_double = [&property_name, &property_value_str, &joint_name](double& prop_value) -> bool {
+      auto parse_property_double = [&joint_name](auto& prop_name, auto& prop_value_str, double& prop_value) -> bool {
         try
         {
-          prop_value = moveit::core::toDouble(property_value_str);
+          prop_value = moveit::core::toDouble(prop_value_str);
           return true;
         }
         catch (const std::runtime_error& e)
         {
-          ROS_ERROR_STREAM_NAMED(LOGNAME, "Unable to parse property " << property_name << " for joint " << joint_name
-                                                                      << " as double: '" << property_value_str << "'");
+          ROS_ERROR_STREAM_NAMED(LOGNAME, "Unable to parse property " << prop_name << " for joint " << joint_name
+                                                                      << " as double: '" << prop_value_str << "'");
         }
         return false;
       };
@@ -1001,7 +1001,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
       if (property_name == "angular_distance_weight")
       {
         double angular_distance_weight;
-        if (parse_property_double(angular_distance_weight))
+        if (parse_property_double(property_name, property_value_str, angular_distance_weight))
         {
           if (new_joint_model->getType() == JointModel::JointType::PLANAR)
           {
@@ -1055,7 +1055,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
           continue;
         }
         double min_translational_distance;
-        if (parse_property_double(min_translational_distance))
+        if (parse_property_double(property_name, property_value_str, min_translational_distance))
         {
           ((PlanarJointModel*)new_joint_model)->setMinTranslationalDistance(min_translational_distance);
         }

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -968,7 +968,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
   {
     new_joint_model->setDistanceFactor(new_joint_model->getStateSpaceDimension());
     const std::vector<srdf::Model::PassiveJoint>& pjoints = srdf_model.getPassiveJoints();
-    std::string joint_name = new_joint_model->getName();
+    const std::string& joint_name = new_joint_model->getName();
     for (const srdf::Model::PassiveJoint& pjoint : pjoints)
     {
       if (joint_name == pjoint.name_)
@@ -977,10 +977,8 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
         break;
       }
     }
-    for (const auto& property : srdf_model.getJointProperties(joint_name))
+    for (const auto& [property_name, property_value] : srdf_model.getJointProperties(joint_name))
     {
-      std::string property_name = property.first;
-      std::string property_value = property.second;
       if (property_name == "angular_distance_weight")
       {
         double angular_distance_weight;

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -987,9 +987,9 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
           angular_distance_weight = std::stod(property.value_, &sz);
           if (sz != property.value_.size())
           {
-            ROS_WARN_STREAM_NAMED(LOGNAME, "Extra characters after property " << property.property_name_ << " for joint "
-                                                                              << property.joint_name_ << " as double: '"
-                                                                              << property.value_.substr(sz) << "'");
+            ROS_WARN_STREAM_NAMED(LOGNAME, "Extra characters after property "
+                                               << property.property_name_ << " for joint " << property.joint_name_
+                                               << " as double: '" << property.value_.substr(sz) << "'");
           }
         }
         catch (const std::invalid_argument& e)
@@ -1010,17 +1010,15 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
         }
         else
         {
-          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s",
-                                   property.property_name_.c_str(),
-                                   new_joint_model->getTypeName().c_str());
+          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s", property.property_name_.c_str(),
+                          new_joint_model->getTypeName().c_str());
         }
       }
       else if (property.property_name_ == "motion_model")
       {
         if (new_joint_model->getType() != JointModel::JointType::PLANAR)
         {
-          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s",
-                          property.property_name_.c_str(),
+          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s", property.property_name_.c_str(),
                           new_joint_model->getTypeName().c_str());
           continue;
         }
@@ -1037,8 +1035,8 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
         else
         {
           ROS_ERROR_STREAM_NAMED(LOGNAME, "Unknown value for property " << property.property_name_ << " ("
-                                                                        << property.joint_name_ << "): '" << property.value_
-                                                                        << "'");
+                                                                        << property.joint_name_ << "): '"
+                                                                        << property.value_ << "'");
           ROS_ERROR_NAMED(LOGNAME, "Valid values are 'holonomic' and 'diff_drive'");
           continue;
         }
@@ -1049,8 +1047,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
       {
         if (new_joint_model->getType() != JointModel::JointType::PLANAR)
         {
-          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s",
-                          property.property_name_.c_str(),
+          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s", property.property_name_.c_str(),
                           new_joint_model->getTypeName().c_str());
           continue;
         }
@@ -1061,17 +1058,15 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
           min_translational_distance = std::stod(property.value_, &sz);
           if (sz != property.value_.size())
           {
-            ROS_WARN_STREAM_NAMED(LOGNAME, "Extra characters after property " << property.property_name_ << " for joint "
-                                                                       << property.joint_name_ << " as double: '"
-                                                                       << property.value_.substr(sz) << "'");
+            ROS_WARN_STREAM_NAMED(LOGNAME, "Extra characters after property "
+                                               << property.property_name_ << " for joint " << property.joint_name_
+                                               << " as double: '" << property.value_.substr(sz) << "'");
           }
         }
         catch (const std::invalid_argument& e)
         {
           ROS_ERROR_NAMED(LOGNAME, "Unable to parse property %s for joint %s as double: '%s'",
-                          property.property_name_.c_str(),
-                          property.joint_name_.c_str(),
-                          property.value_.c_str());
+                          property.property_name_.c_str(), property.joint_name_.c_str(), property.value_.c_str());
           continue;
         }
 

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -976,6 +976,112 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
         break;
       }
     }
+    for (const srdf::Model::JointProperty& property : srdf_model.getJointProperties(new_joint_model->getName()))
+    {
+      if (property.property_name_ == "angular_distance_weight")
+      {
+        double angular_distance_weight;
+        try
+        {
+          std::string::size_type sz;
+          angular_distance_weight = std::stod(property.value_, &sz);
+          if (sz != property.value_.size())
+          {
+            ROS_WARN_STREAM_NAMED(LOGNAME, "Extra characters after property " << property.property_name_ << " for joint "
+                                                                              << property.joint_name_ << " as double: '"
+                                                                              << property.value_.substr(sz) << "'");
+          }
+        }
+        catch (const std::invalid_argument& e)
+        {
+          ROS_ERROR_STREAM_NAMED(LOGNAME, "Unable to parse property " << property.property_name_ << " for joint "
+                                                                      << property.joint_name_ << " as double: '"
+                                                                      << property.value_ << "'");
+          continue;
+        }
+
+        if (new_joint_model->getType() == JointModel::JointType::PLANAR)
+        {
+          ((PlanarJointModel*)new_joint_model)->setAngularDistanceWeight(angular_distance_weight);
+        }
+        else if (new_joint_model->getType() == JointModel::JointType::FLOATING)
+        {
+          ((FloatingJointModel*)new_joint_model)->setAngularDistanceWeight(angular_distance_weight);
+        }
+        else
+        {
+          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s",
+                                   property.property_name_.c_str(),
+                                   new_joint_model->getTypeName().c_str());
+        }
+      }
+      else if (property.property_name_ == "motion_model")
+      {
+        if (new_joint_model->getType() != JointModel::JointType::PLANAR)
+        {
+          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s",
+                          property.property_name_.c_str(),
+                          new_joint_model->getTypeName().c_str());
+          continue;
+        }
+
+        PlanarJointModel::MotionModel motion_model;
+        if (property.value_ == "holonomic")
+        {
+          motion_model = PlanarJointModel::MotionModel::HOLONOMIC;
+        }
+        else if (property.value_ == "diff_drive")
+        {
+          motion_model = PlanarJointModel::MotionModel::DIFF_DRIVE;
+        }
+        else
+        {
+          ROS_ERROR_STREAM_NAMED(LOGNAME, "Unknown value for property " << property.property_name_ << " ("
+                                                                        << property.joint_name_ << "): '" << property.value_
+                                                                        << "'");
+          ROS_ERROR_NAMED(LOGNAME, "Valid values are 'holonomic' and 'diff_drive'");
+          continue;
+        }
+
+        ((PlanarJointModel*)new_joint_model)->setMotionModel(motion_model);
+      }
+      else if (property.property_name_ == "min_translational_distance")
+      {
+        if (new_joint_model->getType() != JointModel::JointType::PLANAR)
+        {
+          ROS_ERROR_NAMED(LOGNAME, "Cannot apply property %s to joint type: %s",
+                          property.property_name_.c_str(),
+                          new_joint_model->getTypeName().c_str());
+          continue;
+        }
+        double min_translational_distance;
+        try
+        {
+          std::string::size_type sz;
+          min_translational_distance = std::stod(property.value_, &sz);
+          if (sz != property.value_.size())
+          {
+            ROS_WARN_STREAM_NAMED(LOGNAME, "Extra characters after property " << property.property_name_ << " for joint "
+                                                                       << property.joint_name_ << " as double: '"
+                                                                       << property.value_.substr(sz) << "'");
+          }
+        }
+        catch (const std::invalid_argument& e)
+        {
+          ROS_ERROR_NAMED(LOGNAME, "Unable to parse property %s for joint %s as double: '%s'",
+                          property.property_name_.c_str(),
+                          property.joint_name_.c_str(),
+                          property.value_.c_str());
+          continue;
+        }
+
+        ((PlanarJointModel*)new_joint_model)->setMinTranslationalDistance(min_translational_distance);
+      }
+      else
+      {
+        ROS_ERROR_NAMED(LOGNAME, "Unknown joint property: %s", property.property_name_.c_str());
+      }
+    }
   }
 
   return new_joint_model;

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -984,7 +984,7 @@ JointModel* RobotModel::constructJointModel(const urdf::Joint* urdf_joint, const
       // if the property was successfully parsed,
       // stores the resulting property value in prop_value and returns true
       // otherwise logs a ROS_ERROR and returns false
-      auto parse_property_double = [&](double& prop_value) -> bool {
+      auto parse_property_double = [&property_name, &property_value_str, &joint_name](double& prop_value) -> bool {
         try
         {
           prop_value = moveit::core::toDouble(property_value_str);

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -185,6 +185,13 @@ public:
   RobotModelBuilder& addEndEffector(const std::string& name, const std::string& parent_link,
                                     const std::string& parent_group = "", const std::string& component_group = "");
 
+  /** \brief Adds a new joint property
+   *  \param[in] joint_name The name of the joint the property is specified for
+   *  \param[in] property_name The joint property name
+   *  \param[in] value The value of the joint property
+   */
+  void addJointProperty(const std::string& joint_name, const std::string& property_name, const std::string& value);
+
   /** \} */
 
   /** \brief Returns true if the building process so far has been valid. */

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -394,6 +394,12 @@ RobotModelBuilder& RobotModelBuilder::addEndEffector(const std::string& name, co
   return *this;
 }
 
+void RobotModelBuilder::addJointProperty(const std::string& joint_name, const std::string& property_name,
+                                         const std::string& value)
+{
+  srdf_writer_->joint_properties_[joint_name].push_back({ joint_name, property_name, value });
+}
+
 bool RobotModelBuilder::isValid()
 {
   return is_valid_;

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -397,7 +397,7 @@ RobotModelBuilder& RobotModelBuilder::addEndEffector(const std::string& name, co
 void RobotModelBuilder::addJointProperty(const std::string& joint_name, const std::string& property_name,
                                          const std::string& value)
 {
-  srdf_writer_->joint_properties_[joint_name].push_back({ joint_name, property_name, value });
+  srdf_writer_->joint_properties_[joint_name][property_name] = value;
 }
 
 bool RobotModelBuilder::isValid()

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -198,18 +198,7 @@ TEST(TestDiffDrive, TestStateSpace)
   ompl_interface::JointModelStateSpace ss(spec);
   ss.setPlanningVolume(-2, 2, -2, 2, -2, 2);
   ss.setup();
-
-  bool passed = false;
-  try
-  {
-    ss.sanityChecks();
-    passed = true;
-  }
-  catch (ompl::Exception& ex)
-  {
-    ROS_ERROR("Sanity checks did not pass: %s", ex.what());
-  }
-  EXPECT_TRUE(passed);
+  ss.sanityChecks();
 }
 
 int main(int argc, char** argv)

--- a/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/test/test_state_space.cpp
@@ -184,6 +184,34 @@ TEST_F(LoadPlanningModelsPr2, StateSpaceCopy)
   joint_model_state_space.freeState(state);
 }
 
+// Run the OMPL sanity checks on the diff drive model
+TEST(TestDiffDrive, TestStateSpace)
+{
+  moveit::core::RobotModelBuilder builder("mobile_base", "base_link");
+  builder.addVirtualJoint("odom_combined", "base_link", "planar", "base_joint");
+  builder.addJointProperty("base_joint", "motion_model", "diff_drive");
+  builder.addGroup({}, { "base_joint" }, "base");
+  ASSERT_TRUE(builder.isValid());
+
+  auto robot_model = builder.build();
+  ompl_interface::ModelBasedStateSpaceSpecification spec(robot_model, "base");
+  ompl_interface::JointModelStateSpace ss(spec);
+  ss.setPlanningVolume(-2, 2, -2, 2, -2, 2);
+  ss.setup();
+
+  bool passed = false;
+  try
+  {
+    ss.sanityChecks();
+    passed = true;
+  }
+  catch (ompl::Exception& ex)
+  {
+    ROS_ERROR("Sanity checks did not pass: %s", ex.what());
+  }
+  EXPECT_TRUE(passed);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
### Description

This PR is a backport of https://github.com/ros-planning/moveit2/pull/390 that implements a differential drive model for planar joints.

After backporting JointProperties into srdfdom for ROS1 (merged in https://github.com/ros-planning/srdfdom/pull/109), we can now specify a planar joint to have a `motion_model` property, which can be set to `holonomic` or `diff_drive` with:
```
<virtual_joint name="position" type="planar" parent_frame="odom" child_link="base_link"/>
<joint_property joint_name="position" property_name="motion_model" value="diff_drive" />
<joint_property joint_name="position" property_name="min_translational_distance" value="0.01" />
```

This PR is a backport of differential drive kinematics from MoveIt2 that are used when the planar joint is set to `diff_drive`.

The difference between planning for holonomic and differential drive enabled by this PR can be seen below, with the differential drive taking a rotate -> drive -> rotate approach compared to holonomic bases that can go straight to the specified goal position.

#### Holonomic:
![Holonomic Robot Planning](https://user-images.githubusercontent.com/11098209/222594219-cd5b4ded-f20f-48c9-ad82-f974dd472a57.gif)


#### Differential Drive:
![Differential Drive Robot Planning](https://user-images.githubusercontent.com/11098209/222594211-519b4ad6-8667-4a9c-808f-2878a675f51d.gif)


### Open Issues with Differential Drive Planning in MoveIt

Unfortunately, there are still some open issues I've encountered in the rest of the motion planning pipeline that prevents differential drive bases from being plug and play with MoveIt1. These will likely have to be addressed with separate PRs outside of this backport.

These issues include:
1. **Plan Execution**: Hitting the "execute" button on either of the planning screens above only moves the arm and not the base. I suspect this is because MoveIt! does not seem to handle publishing of planar joint states by default, nor do the corresponding "fake controllers" know what to do with these multi-dof joints.
2. ~~**Limited Workspaces**:  The default workspace of the robot seems to be limited to the blue cube visualized below. Trying to move the base outside this workspace results in a failure to plan, despite it being just open space.~~ I figured it out. There are fields in the Rviz GUI for specifying the workspace under the `Context` tab of the `MotionPlan` rviz tab. I'm still wondering where the default (2, 2, 2) values are set.
3. **Missing Parent Links:** The `dynamics_solver` complains that the planning group with planar joint does not have a parent link. This error is triggered [here](https://github.com/ros-planning/moveit/blob/326e9b5fe76bdf856f9c4a2be56ce7e136651ff2/moveit_core/dynamics_solver/src/dynamics_solver.cpp#L91) because the virtual planar joint that connects the base of the robot to an external frame does not have a proper parent link. I am not sure what are the consequences of not having the dynamics solver instantiated, but this does cause some `[ERROR]` messages to pop up.
4. When `moveit_core` is built as `Debug`, if the goal position of the base is rotated using the Rviz gui, the `ASSERT_ISOMETRY` [here](https://github.com/ros-planning/moveit/blob/326e9b5fe76bdf856f9c4a2be56ce7e136651ff2/moveit_core/robot_model/src/planar_joint_model.cpp#L228) fails and crashes the program. Despite this issue, when we build the package as `Release`, no error is reported and things seem to work correctly even if the assertion condition is not met.

I am looking for some guidance in resolving these issues, given my relative unfamiliarity with the inner workings of this aspect of the planning pipeline. If anyone has any insights into how I may fix these issues, please let me know.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
