### PR TITLE
Add a version of TOTG `computeTimeStamps()` for combining sub-trajectories

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -167,8 +167,27 @@ public:
   TimeOptimalTrajectoryGeneration(const double path_tolerance = 0.1, const double resample_dt = 0.1,
                                   const double min_angle_change = 0.001);
 
+  /** @brief Compute velocities and accelerations along the input path. Assumes the robot starts and ends
+      at rest.
+      @param[in,out] trajectory Waypoints are taken as the input path. Velocities and accelerations are filled for output.
+      @param max_velocity_scaling_factor A factor in the range (0, 1]
+      @param max_acceleration_scaling_factor A factor in the range (0, 1]
+      @return true if successful
+   */
   bool computeTimeStamps(robot_trajectory::RobotTrajectory& trajectory, const double max_velocity_scaling_factor = 1.0,
                          const double max_acceleration_scaling_factor = 1.0) const override;
+
+  /** @brief Combine the waypoints from several trajectories into one longer path, then compute velocities and
+      accelerations. Assumes the robot starts and ends at rest.
+      @param input_trajs Waypoints are combined as the input path.
+      @param max_velocity_scaling_factor A factor in the range (0, 1]
+      @param max_acceleration_scaling_factor A factor in the range (0, 1]
+      @param[out] output_traj Output trajectory, with velocities and accelerations filled.
+      @return true if successful
+   */
+  bool computeTimeStamps(const std::vector<robot_trajectory::RobotTrajectory>& input_trajs,
+                         robot_trajectory::RobotTrajectory& output_traj, const double max_velocity_scaling_factor = 1.0,
+                         const double max_acceleration_scaling_factor = 1.0) const;
 
 private:
   const double path_tolerance_;

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -1026,4 +1026,22 @@ bool TimeOptimalTrajectoryGeneration::computeTimeStamps(robot_trajectory::RobotT
 
   return true;
 }
+
+bool TimeOptimalTrajectoryGeneration::computeTimeStamps(
+    const std::vector<robot_trajectory::RobotTrajectory>& input_trajs, robot_trajectory::RobotTrajectory& output_traj,
+    const double max_velocity_scaling_factor, const double max_acceleration_scaling_factor) const
+{
+  if (input_trajs.empty())
+  {
+    return false;
+  }
+
+  output_traj.clear();
+  for (const robot_trajectory::RobotTrajectory& traj : input_trajs)
+  {
+    output_traj.append(traj, 0.1 /* dt doesn't matter, will be overwritten*/);
+  }
+
+  return computeTimeStamps(output_traj, max_velocity_scaling_factor, max_acceleration_scaling_factor);
+}
 }  // namespace trajectory_processing


### PR DESCRIPTION
### Description

If the user has planned several sub-paths or trajectories, they often want to combine them and re-parameterize so the motion is smooth.
