### PR TITLE
Skip executing zero-duration trajectories

### DIFF
--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -819,8 +819,8 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
 {
   if (trajectory.multi_dof_joint_trajectory.points.empty() &&
       (trajectory.joint_trajectory.points.empty() ||
-       trajectory.joint_trajectory.header.stamp + trajectory.joint_trajectory.points.back().time_from_start ==
-           ros::Time()))
+       // zero-duration trajectory (start-time stamp + overall duration == 0) causes controller issues
+       (trajectory.joint_trajectory.header.stamp + trajectory.joint_trajectory.points.back().time_from_start).isZero()))
   {
     // empty trajectories don't need to configure anything
     return true;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -817,7 +817,10 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
                                            const moveit_msgs::RobotTrajectory& trajectory,
                                            const std::vector<std::string>& controllers)
 {
-  if (trajectory.multi_dof_joint_trajectory.points.empty() && trajectory.joint_trajectory.points.empty())
+  if (trajectory.multi_dof_joint_trajectory.points.empty() &&
+      (trajectory.joint_trajectory.points.empty() ||
+       trajectory.joint_trajectory.header.stamp + trajectory.joint_trajectory.points.back().time_from_start ==
+           ros::Time()))
   {
     // empty trajectories don't need to configure anything
     return true;

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -817,14 +817,18 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
                                            const moveit_msgs::RobotTrajectory& trajectory,
                                            const std::vector<std::string>& controllers)
 {
-  if (trajectory.multi_dof_joint_trajectory.points.empty() &&
-      (trajectory.joint_trajectory.points.empty() ||
-       // zero-duration trajectory (start-time stamp + overall duration == 0) causes controller issues
-       (trajectory.joint_trajectory.header.stamp + trajectory.joint_trajectory.points.back().time_from_start).isZero()))
+  // empty trajectories don't need to configure anything
+  if (trajectory.multi_dof_joint_trajectory.points.empty() && trajectory.joint_trajectory.points.empty())
+    return true;
+
+  // zero-duration trajectory (start-time stamp + overall duration == 0) causes controller issues
+  if ((trajectory.joint_trajectory.header.stamp + trajectory.joint_trajectory.points.back().time_from_start).isZero())
   {
-    // empty trajectories don't need to configure anything
+    // https://github.com/ros-planning/moveit/pull/3362
+    ROS_DEBUG_STREAM_NAMED(LOGNAME, "Skipping zero-duration trajectory");
     return true;
   }
+
   std::set<std::string> actuated_joints;
 
   auto is_actuated = [this](const std::string& joint_name) -> bool {


### PR DESCRIPTION
zero-duration trajectories cause the default ROS joint trajectory controller to [fail](https://github.com/ros-planning/moveit_task_constructor/issues/433#issuecomment-1456178725): 
`Dropping all 1 trajectory point(s), as they occur before the current time. Last point is 0.000000s in the past.`

In contrast to https://github.com/ros-planning/moveit_task_constructor/pull/438, I looked for the _latest_ possibility to skip those trajectories. I explicitly decided not to prune in `RobotTrajectory` message generation already, but only just before execution.