### PR TITLE
Fix MoveItCpp issues

### DIFF
--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -285,7 +285,7 @@ int main(int argc, char** argv)
   // Initialize MoveItCpp
   const auto tf_buffer = std::make_shared<tf2_ros::Buffer>(ros::Duration(10.0));
   const auto moveit_cpp = std::make_shared<moveit_cpp::MoveItCpp>(moveit_cpp_options, pnh, tf_buffer);
-  const auto planning_scene_monitor = moveit_cpp->getPlanningSceneMonitor();
+  const auto planning_scene_monitor = moveit_cpp->getPlanningSceneMonitorNonConst();
 
   if (planning_scene_monitor->getPlanningScene())
   {

--- a/moveit_ros/move_group/src/move_group_context.cpp
+++ b/moveit_ros/move_group/src/move_group_context.cpp
@@ -45,7 +45,7 @@ move_group::MoveGroupContext::MoveGroupContext(const moveit_cpp::MoveItCppPtr& m
                                                const std::string& default_planning_pipeline,
                                                bool allow_trajectory_execution, bool debug)
   : moveit_cpp_(moveit_cpp)
-  , planning_scene_monitor_(moveit_cpp->getPlanningSceneMonitor())
+  , planning_scene_monitor_(moveit_cpp->getPlanningSceneMonitorNonConst())
   , allow_trajectory_execution_(allow_trajectory_execution)
   , debug_(debug)
 {
@@ -72,7 +72,7 @@ move_group::MoveGroupContext::MoveGroupContext(const moveit_cpp::MoveItCppPtr& m
 
   if (allow_trajectory_execution_)
   {
-    trajectory_execution_manager_ = moveit_cpp_->getTrajectoryExecutionManager();
+    trajectory_execution_manager_ = moveit_cpp_->getTrajectoryExecutionManagerNonConst();
     plan_execution_ =
         std::make_shared<plan_execution::PlanExecution>(planning_scene_monitor_, trajectory_execution_manager_);
     plan_with_sensing_ = std::make_shared<plan_execution::PlanWithSensing>(trajectory_execution_manager_);

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -143,13 +143,14 @@ public:
   const std::map<std::string, planning_pipeline::PlanningPipelinePtr>& getPlanningPipelines() const;
 
   /** \brief Get the stored instance of the planning scene monitor */
-  const planning_scene_monitor::PlanningSceneMonitorPtr& getPlanningSceneMonitor() const;
+  planning_scene_monitor::PlanningSceneMonitorConstPtr getPlanningSceneMonitor() const;
   planning_scene_monitor::PlanningSceneMonitorPtr getPlanningSceneMonitorNonConst();
 
-  const std::shared_ptr<tf2_ros::Buffer>& getTFBuffer() const;
+  std::shared_ptr<const tf2_ros::Buffer> getTFBuffer() const;
+  std::shared_ptr<tf2_ros::Buffer> getTFBuffer();
 
   /** \brief Get the stored instance of the trajectory execution manager */
-  const trajectory_execution_manager::TrajectoryExecutionManagerPtr& getTrajectoryExecutionManager() const;
+  trajectory_execution_manager::TrajectoryExecutionManagerConstPtr getTrajectoryExecutionManager() const;
   trajectory_execution_manager::TrajectoryExecutionManagerPtr getTrajectoryExecutionManagerNonConst();
 
   /** \brief Execute a trajectory on the planning group specified by group_name using the trajectory execution manager.

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -168,7 +168,6 @@ protected:
 private:
   //  Core properties and instances
   ros::NodeHandle node_handle_;
-  moveit::core::RobotModelConstPtr robot_model_;
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
   // Planning
@@ -177,9 +176,6 @@ private:
 
   // Execution
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;
-
-  /** \brief Reset all member variables */
-  void clearContents();
 
   /** \brief Initialize and setup the planning scene monitor */
   bool loadPlanningSceneMonitor(const PlanningSceneMonitorOptions& options);

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -199,7 +199,7 @@ const std::map<std::string, planning_pipeline::PlanningPipelinePtr>& MoveItCpp::
   return planning_pipelines_;
 }
 
-const planning_scene_monitor::PlanningSceneMonitorPtr& MoveItCpp::getPlanningSceneMonitor() const
+planning_scene_monitor::PlanningSceneMonitorConstPtr MoveItCpp::getPlanningSceneMonitor() const
 {
   return planning_scene_monitor_;
 }
@@ -209,7 +209,7 @@ planning_scene_monitor::PlanningSceneMonitorPtr MoveItCpp::getPlanningSceneMonit
   return planning_scene_monitor_;
 }
 
-const trajectory_execution_manager::TrajectoryExecutionManagerPtr& MoveItCpp::getTrajectoryExecutionManager() const
+trajectory_execution_manager::TrajectoryExecutionManagerConstPtr MoveItCpp::getTrajectoryExecutionManager() const
 {
   return trajectory_execution_manager_;
 }
@@ -268,7 +268,11 @@ bool MoveItCpp::terminatePlanningPipeline(std::string const& pipeline_name)
   }
 }
 
-const std::shared_ptr<tf2_ros::Buffer>& MoveItCpp::getTFBuffer() const
+std::shared_ptr<const tf2_ros::Buffer> MoveItCpp::getTFBuffer() const
+{
+  return tf_buffer_;
+}
+std::shared_ptr<tf2_ros::Buffer> MoveItCpp::getTFBuffer()
 {
   return tf_buffer_;
 }

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -63,8 +63,7 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
     throw std::runtime_error(error);
   }
 
-  robot_model_ = planning_scene_monitor_->getRobotModel();
-  if (!robot_model_)
+  if (!getRobotModel())
   {
     const std::string error = "Unable to construct robot model. Please make sure all needed information is on the "
                               "parameter server.";
@@ -82,7 +81,7 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
 
   // TODO(henningkayser): configure trajectory execution manager
   trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-      robot_model_, planning_scene_monitor_->getStateMonitor());
+      getRobotModel(), planning_scene_monitor_->getStateMonitor());
 
   ROS_DEBUG_NAMED(LOGNAME, "MoveItCpp running");
 }
@@ -90,7 +89,6 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
 MoveItCpp::~MoveItCpp()
 {
   ROS_INFO_NAMED(LOGNAME, "Deleting MoveItCpp");
-  clearContents();
 }
 
 bool MoveItCpp::loadPlanningSceneMonitor(const PlanningSceneMonitorOptions& options)
@@ -142,7 +140,7 @@ bool MoveItCpp::loadPlanningPipelines(const PlanningPipelineOptions& options)
     ROS_INFO_NAMED(LOGNAME, "Loading planning pipeline '%s'", planning_pipeline_name.c_str());
     ros::NodeHandle child_nh(node_handle, planning_pipeline_name);
     planning_pipeline::PlanningPipelinePtr pipeline;
-    pipeline = std::make_shared<planning_pipeline::PlanningPipeline>(robot_model_, child_nh, PLANNING_PLUGIN_PARAM);
+    pipeline = std::make_shared<planning_pipeline::PlanningPipeline>(getRobotModel(), child_nh, PLANNING_PLUGIN_PARAM);
 
     if (!pipeline->getPlannerManager())
     {
@@ -164,7 +162,7 @@ bool MoveItCpp::loadPlanningPipelines(const PlanningPipelineOptions& options)
 
 moveit::core::RobotModelConstPtr MoveItCpp::getRobotModel() const
 {
-  return robot_model_;
+  return planning_scene_monitor_->getRobotModel();
 }
 
 const ros::NodeHandle& MoveItCpp::getNodeHandle() const
@@ -277,12 +275,4 @@ std::shared_ptr<tf2_ros::Buffer> MoveItCpp::getTFBuffer()
   return tf_buffer_;
 }
 
-void MoveItCpp::clearContents()
-{
-  tf_listener_.reset();
-  tf_buffer_.reset();
-  planning_scene_monitor_.reset();
-  robot_model_.reset();
-  planning_pipelines_.clear();
-}
 }  // namespace moveit_cpp

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.cpp
@@ -57,7 +57,7 @@ public:
   {
     nh_ = ros::NodeHandle();
     moveit_cpp_ptr = std::make_shared<MoveItCpp>(nh_);
-    trajectory_execution_manager_ptr = moveit_cpp_ptr->getTrajectoryExecutionManager();
+    trajectory_execution_manager_ptr = moveit_cpp_ptr->getTrajectoryExecutionManagerNonConst();
 
     traj1.joint_trajectory.joint_names.push_back("panda_joint1");
     traj1.joint_trajectory.points.resize(1);


### PR DESCRIPTION
- Fix `const` member accessors. They should return a `ConstPtr` instead of a `const Ptr&`!
- Fix SEVERE ClassLoader warning on destruction of `MoveItCpp`:
  - PSM was released before copy of its RobotModel -> removed extra RobotModel copy
  - `clearContents()` was broken:
    - resets in wrong order: psm_ should be last
    - trajectory_execution_manager_ was missing
    
    I suggest to omit `clearContents()` and just rely on the (correct) ordering of member variables.
    While this is not explicit, we ensure that we don't miss any newly added member variable.
