### PR TITLE
Check for a Ruckig jerk limit parameter

### DIFF
--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -253,8 +253,7 @@ bool RuckigSmoothing::getRobotModelBounds(const double max_velocity_scaling_fact
                        << " rad/s^2. You can define acceleration limits in the URDF or joint_limits.yaml.");
       ruckig_input.max_acceleration.at(i) = max_acceleration_scaling_factor * DEFAULT_MAX_ACCELERATION;
     }
-    // TODO(andyz): Add bounds.jerk_bounded_ for MoveIt1
-    // For now, we check for a jerk parameter
+    // Read jerk limits from parameters since bounds.jerk_bounded_ was never implemented for MoveIt1
     ros::NodeHandle nh;
     double jerk_limit = DEFAULT_MAX_JERK;
     std::string jerk_param = "ruckig/" + vars.at(i) + "/jerk_limit";
@@ -265,9 +264,10 @@ bool RuckigSmoothing::getRobotModelBounds(const double max_velocity_scaling_fact
     else
     {
       ruckig_input.max_jerk.at(i) = DEFAULT_MAX_JERK;
-      ROS_WARN_STREAM_ONCE_NAMED(
-          LOGNAME, "Joint jerk limit for joint " + vars.at(i) + " was not defined. Using the default "
-                       << DEFAULT_MAX_JERK << " rad/s^3. You can define a jerk limit with parameter " + jerk_param);
+      ROS_WARN_STREAM_NAMED(LOGNAME, "Joint jerk limit for joint " + vars.at(i) + " was not defined. Using the default "
+                                         << DEFAULT_MAX_JERK
+                                         << " rad/s^3. You can define a jerk limit with parameter " +
+                                                nh.getNamespace() + jerk_param);
     }
   }
 

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -38,6 +38,7 @@
 #include <Eigen/Geometry>
 #include <limits>
 #include <moveit/trajectory_processing/ruckig_traj_smoothing.h>
+#include <ros/ros.h>
 #include <vector>
 
 namespace trajectory_processing
@@ -254,10 +255,9 @@ bool RuckigSmoothing::getRobotModelBounds(const double max_velocity_scaling_fact
       ruckig_input.max_acceleration.at(i) = max_acceleration_scaling_factor * DEFAULT_MAX_ACCELERATION;
     }
     // Read jerk limits from parameters since bounds.jerk_bounded_ was never implemented for MoveIt1
-    ros::NodeHandle nh;
     double jerk_limit = DEFAULT_MAX_JERK;
     std::string jerk_param = "ruckig/" + vars.at(i) + "/jerk_limit";
-    if (nh.getParam(jerk_param, jerk_limit))
+    if (ros::param::get(jerk_param, jerk_limit))
     {
       ruckig_input.max_jerk.at(i) = jerk_limit;
     }
@@ -266,8 +266,7 @@ bool RuckigSmoothing::getRobotModelBounds(const double max_velocity_scaling_fact
       ruckig_input.max_jerk.at(i) = DEFAULT_MAX_JERK;
       ROS_WARN_STREAM_NAMED(LOGNAME, "Joint jerk limit for joint " + vars.at(i) + " was not defined. Using the default "
                                          << DEFAULT_MAX_JERK
-                                         << " rad/s^3. You can define a jerk limit with parameter " +
-                                                nh.getNamespace() + jerk_param);
+                                         << " rad/s^3. You can define a jerk limit with parameter " + jerk_param);
     }
   }
 

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -257,16 +257,17 @@ bool RuckigSmoothing::getRobotModelBounds(const double max_velocity_scaling_fact
     // For now, we check for a jerk parameter
     ros::NodeHandle nh;
     double jerk_limit = DEFAULT_MAX_JERK;
-    if (nh.getParam("ruckig/" + vars.at(i) + "/jerk_limit", jerk_limit))
+    std::string jerk_param = "ruckig/" + vars.at(i) + "/jerk_limit";
+    if (nh.getParam(jerk_param, jerk_limit))
     {
       ruckig_input.max_jerk.at(i) = jerk_limit;
     }
     else
     {
       ruckig_input.max_jerk.at(i) = DEFAULT_MAX_JERK;
-      ROS_WARN_STREAM_ONCE_NAMED(LOGNAME, "Joint jerk limits are not defined. Using the default "
-                                              << DEFAULT_MAX_JERK
-                                              << " rad/s^3. You can define jerk limits in joint_limits.yaml.");
+      ROS_WARN_STREAM_ONCE_NAMED(
+          LOGNAME, "Joint jerk limit for joint " + vars.at(i) + " was not defined. Using the default "
+                       << DEFAULT_MAX_JERK << " rad/s^3. You can define a jerk limit with parameter " + jerk_param);
     }
   }
 

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -254,10 +254,20 @@ bool RuckigSmoothing::getRobotModelBounds(const double max_velocity_scaling_fact
       ruckig_input.max_acceleration.at(i) = max_acceleration_scaling_factor * DEFAULT_MAX_ACCELERATION;
     }
     // TODO(andyz): Add bounds.jerk_bounded_ for MoveIt1
-    ruckig_input.max_jerk.at(i) = DEFAULT_MAX_JERK;
-    ROS_WARN_STREAM_ONCE_NAMED(LOGNAME, "Joint jerk limits are not defined. Using the default "
-                                            << DEFAULT_MAX_JERK
-                                            << " rad/s^3. You can define jerk limits in joint_limits.yaml.");
+    // For now, we check for a jerk parameter
+    ros::NodeHandle nh;
+    double jerk_limit = DEFAULT_MAX_JERK;
+    if (nh.getParam("ruckig/" + vars.at(i) + "/jerk_limit", jerk_limit))
+    {
+      ruckig_input.max_jerk.at(i) = jerk_limit;
+    }
+    else
+    {
+      ruckig_input.max_jerk.at(i) = DEFAULT_MAX_JERK;
+      ROS_WARN_STREAM_ONCE_NAMED(LOGNAME, "Joint jerk limits are not defined. Using the default "
+                                              << DEFAULT_MAX_JERK
+                                              << " rad/s^3. You can define jerk limits in joint_limits.yaml.");
+    }
   }
 
   return true;


### PR DESCRIPTION
### Description

We want the ability to set custom joint jerk limits for the Ruckig smoother, but in MoveIt1, the RobotModel does not contain that info. My feeling is, there probably isn't a desire to create a large API-breaking PR in MoveIt1 for adding a jerk limit. Here's what adding jerk to the RobotModel would look like, from MoveIt2:  https://github.com/ros-planning/moveit2/pull/683

So, I made this small, simple PR to add a ROS jerk limit parameter.

### Test instructions

I've been testing like this:

1. Add Ruckig jerk params to `panda_moveit_config/launch/demo.launch`
  - `<param name="/ruckig/panda_joint1/jerk_limit" type="double" value="300.0" />`  (and so on)
2. Add the Ruckig smoothing adapter to the top of the list at ompl_planning_pipeline.launch.xml
  - default="default_planner_request_adapters/AddRuckigTrajectorySmoothing
3. Launch with:  `roslaunch moveit_resources_panda_moveit_config demo.launch rviz_tutorial:=true`