### PR TITLE
handling different encodings of depth images correctly

### DIFF
--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -126,7 +126,7 @@ void mesh_filter::DepthSelfFiltering::filter(const sensor_msgs::ImageConstPtr& d
     mesh_filter_->filter(reinterpret_cast<const float*>(depth_msg->data.data()), GL_FLOAT);
   else
   {
-   ROS_WARN_STREAM_THROTTLE_NAMED(1.0, LOGNAME, "Unsupported encoding of depth image: " << depth_msg->encoding);
+    ROS_WARN_STREAM_THROTTLE_NAMED(1.0, LOGNAME, "Unsupported encoding of depth image: " << depth_msg->encoding);
     return;
   }
 

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -45,6 +45,7 @@
 #include <cv_bridge/cv_bridge.h>
 
 namespace enc = sensor_msgs::image_encodings;
+static const std::string LOGNAME = "depth_self_filter_nodelet";
 
 mesh_filter::DepthSelfFiltering::~DepthSelfFiltering()
 {
@@ -116,8 +117,9 @@ void mesh_filter::DepthSelfFiltering::filter(const sensor_msgs::ImageConstPtr& d
   // Handling of two possible encodings of a depth image: 16UC1 and 32FC1
   if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1)
   {
-    ROS_WARN_STREAM_THROTTLE(1.0, "The input depth image is encoded in the deprecated 16UC1 format, please consider "
-                                  "converting it to 32FC1 according to ROS REP-118!");
+    ROS_WARN_STREAM_ONCE_NAMED(LOGNAME,
+                               "The input depth image uses a 16UC1 encoding. Consider converting the publisher to "
+                               "generate the canonical 32FC1 encoding instead according to ROS REP-118.");
     mesh_filter_->filter(depth_msg->data.data(), GL_UNSIGNED_SHORT);
   }
   else if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1)

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -115,7 +115,11 @@ void mesh_filter::DepthSelfFiltering::filter(const sensor_msgs::ImageConstPtr& d
 
   // Handling of two possible encodings of a depth image: 16UC1 and 32FC1
   if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1)
+  {
+    ROS_WARN_STREAM_THROTTLE(1.0, "The input depth image is encoded in the deprecated 16UC1 format, please consider "
+                                  "converting it to 32FC1 according to ROS REP-118!");
     mesh_filter_->filter(depth_msg->data.data(), GL_UNSIGNED_SHORT);
+  }
   else if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1)
     mesh_filter_->filter(reinterpret_cast<const float*>(depth_msg->data.data()), GL_FLOAT);
   else

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -113,8 +113,16 @@ void mesh_filter::DepthSelfFiltering::filter(const sensor_msgs::ImageConstPtr& d
   params.setCameraParameters(info_msg->K[0], info_msg->K[4], info_msg->K[2], info_msg->K[5]);
   params.setImageSize(depth_msg->width, depth_msg->height);
 
-  const float* src = reinterpret_cast<const float*>(depth_msg->data.data());
-  mesh_filter_->filter(src, GL_FLOAT);
+  // Handling of two possible encodings of a depth image: 16UC1 and 32FC1
+  if (depth_msg->encoding == "16UC1")
+  {
+    mesh_filter_->filter(depth_msg->data.data(), GL_UNSIGNED_SHORT);
+  }
+  else
+  {
+    const float* src = reinterpret_cast<const float*>(depth_msg->data.data());
+    mesh_filter_->filter(src, GL_FLOAT);
+  }
 
   if (pub_filtered_depth_image_.getNumSubscribers() > 0)
   {

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -126,7 +126,7 @@ void mesh_filter::DepthSelfFiltering::filter(const sensor_msgs::ImageConstPtr& d
     mesh_filter_->filter(reinterpret_cast<const float*>(depth_msg->data.data()), GL_FLOAT);
   else
   {
-    ROS_WARN_STREAM_THROTTLE(1.0, "Unsupported encoding of depth image: " << depth_msg->encoding);
+   ROS_WARN_STREAM_THROTTLE_NAMED(1.0, LOGNAME, "Unsupported encoding of depth image: " << depth_msg->encoding);
     return;
   }
 

--- a/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
+++ b/moveit_ros/perception/mesh_filter/src/depth_self_filter_nodelet.cpp
@@ -114,14 +114,14 @@ void mesh_filter::DepthSelfFiltering::filter(const sensor_msgs::ImageConstPtr& d
   params.setImageSize(depth_msg->width, depth_msg->height);
 
   // Handling of two possible encodings of a depth image: 16UC1 and 32FC1
-  if (depth_msg->encoding == "16UC1")
-  {
+  if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_16UC1)
     mesh_filter_->filter(depth_msg->data.data(), GL_UNSIGNED_SHORT);
-  }
+  else if (depth_msg->encoding == sensor_msgs::image_encodings::TYPE_32FC1)
+    mesh_filter_->filter(reinterpret_cast<const float*>(depth_msg->data.data()), GL_FLOAT);
   else
   {
-    const float* src = reinterpret_cast<const float*>(depth_msg->data.data());
-    mesh_filter_->filter(src, GL_FLOAT);
+    ROS_WARN_STREAM_THROTTLE(1.0, "Unsupported encoding of depth image: " << depth_msg->encoding);
+    return;
   }
 
   if (pub_filtered_depth_image_.getNumSubscribers() > 0)


### PR DESCRIPTION
### Description

This is to solve the issue  #3386. The cause of the issue is possibly due to incorrect handling of different encodings of a depth image. The original code assumed the depth image to be encoded in `32FC1` while the depth image returned by Realsense D415 is encoded in `16UC1`.  This issue already existed in the code before the change made to solve #3371.
By using the predefined filter base behavior for `GL_UNSIGNED_SHORT`, the depth image can be properly filtered.
However I don't have other RGBD cameras at hand so I can't know if there is any other encoding used by other cameras, thus I only considered `16UC1` case separately and used the same implementation for all other possible encodings. 

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
