### PR TITLE
MoveGroupCommander.execute can take JointTrajectory argument

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -680,12 +680,15 @@ class MoveGroupCommander(object):
         path.deserialize(ser_path)
         return (path, fraction)
 
-    def execute(self, plan_msg, wait=True):
+    def execute(self, trajectory, wait=True):
         """Execute a previously planned path"""
+        if not hasattr(trajectory, "joint_trajectory"):
+            plan_msg = RobotTrajectory(joint_trajectory=trajectory)
+
         if wait:
-            return self._g.execute(conversions.msg_to_string(plan_msg))
+            return self._g.execute(conversions.msg_to_string(trajectory))
         else:
-            return self._g.async_execute(conversions.msg_to_string(plan_msg))
+            return self._g.async_execute(conversions.msg_to_string(trajectory))
 
     def attach_object(self, object_name, link_name="", touch_links=[]):
         """Given the name of an object existing in the planning scene, attach it to a link. The link used is specified by the second argument. If left unspecified, the end-effector link is used, if one is known. If there is no end-effector link, the first link in the group is used. If no link is identified, failure is reported. True is returned if an attach request was succesfully sent to the move_group node. This does not verify that the attach request also was successfuly applied by move_group."""

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -683,7 +683,7 @@ class MoveGroupCommander(object):
     def execute(self, trajectory, wait=True):
         """Execute a previously planned path"""
         if not hasattr(trajectory, "joint_trajectory"):
-            plan_msg = RobotTrajectory(joint_trajectory=trajectory)
+            trajectory = RobotTrajectory(joint_trajectory=trajectory)
 
         if wait:
             return self._g.execute(conversions.msg_to_string(trajectory))


### PR DESCRIPTION
ChatGPT thought this would be valid and I agree that this simpler call makes sense. :)

Additionally the argument was named wrongly as it implies that the MoveGroupInterface::Plan class has a corresponding ROS message one might pass as argument.

Small quality of life improvement.