### PR TITLE
CSM: do not jump back in time

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/current_state_monitor.cpp
@@ -291,7 +291,7 @@ void CurrentStateMonitor::jointStateCallback(const sensor_msgs::JointStateConstP
     boost::mutex::scoped_lock _(state_update_lock_);
     // read the received values, and update their time stamps
     std::size_t n = joint_state->name.size();
-    current_state_time_ = joint_state->header.stamp;
+    current_state_time_ = std::max(current_state_time_, joint_state->header.stamp);
     for (std::size_t i = 0; i < n; ++i)
     {
       const moveit::core::JointModel* jm = robot_model_->getJointModel(joint_state->name[i]);


### PR DESCRIPTION
- This addresses the use-case where multiple drivers publish joint
  state messages. Of course these do not give any guarantees on the order of
  incoming joint states and can lead to the CSM generating states
  with non-incremental time stamps, thus leading to TrajectoryMonitor recording
  trajectories with non-incremental waypoints.
  A different fix for this might rework the CSM altogether to allow configuring what policy should be employed to synchronize between the different joint publishers, but I believe this approach to use the latest timestamp of anything received is sufficient for the class.

- The downside of the simple fix in the first commit is that the monitor does not work well with
  looping rosbags anymore as the time resets. That's why I added a second commit with minor overhead to restore functionality (slightly more correct than before) when used with a rosbag that loops its time stamps.