### PR TITLE
Fix: TOTG can return vels/accels greater than the limits

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/time_optimal_trajectory_generation.h
@@ -79,7 +79,15 @@ public:
   Eigen::VectorXd getConfig(double s) const;
   Eigen::VectorXd getTangent(double s) const;
   Eigen::VectorXd getCurvature(double s) const;
+
+  /** @brief Get the next switching point.
+   *  @param[in] s Arc length traveled so far
+   *  @param[out] discontinuity True if this switching point is a discontinuity
+   *  @return arc length to the switching point
+   **/
   double getNextSwitchingPoint(double s, bool& discontinuity) const;
+
+  /// @brief Return a list of all switching points as a pair (arc length to switching point, discontinuity)
   std::list<std::pair<double, bool>> getSwitchingPoints() const;
 
 private:

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -327,6 +327,11 @@ Trajectory::Trajectory(const Path& path, const Eigen::VectorXd& max_velocity, co
     {
       break;
     }
+    std::cerr << switching_point.path_pos_ << std::endl;
+    std::cerr << switching_point.path_pos_ << std::endl;
+    std::cerr << switching_point.path_pos_ << std::endl;
+    std::cerr << switching_point.path_pos_ << std::endl;
+    std::cerr << switching_point.path_pos_ << std::endl;
     integrateBackward(trajectory_, switching_point.path_pos_, switching_point.path_vel_, before_acceleration);
   }
 

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -317,7 +317,6 @@ Trajectory::Trajectory(const Path& path, const Eigen::VectorXd& max_velocity, co
   , time_step_(time_step)
   , cached_time_(std::numeric_limits<double>::max())
 {
-  std::cerr << "DOING IT" << std::endl;
   trajectory_.push_back(TrajectoryStep(0.0, 0.0));
   double after_acceleration = getMinMaxPathAcceleration(0.0, 0.0, true);
   while (valid_ && !integrateForward(trajectory_, after_acceleration) && valid_)
@@ -343,9 +342,6 @@ Trajectory::Trajectory(const Path& path, const Eigen::VectorXd& max_velocity, co
     std::list<TrajectoryStep>::iterator previous = trajectory_.begin();
     std::list<TrajectoryStep>::iterator it = previous;
     it->time_ = 0.0;
-    // TOTG requires starting from rest
-    it->path_vel_ = 0.0;
-
     ++it;
     while (it != trajectory_.end())
     {
@@ -354,14 +350,6 @@ Trajectory::Trajectory(const Path& path, const Eigen::VectorXd& max_velocity, co
       previous = it;
       ++it;
     }
-
-    // TOTG requires ending at rest
-    trajectory_.back().path_vel_ = 0.0;
-  }
-
-  for (const TrajectoryStep& step : trajectory_)
-  {
-    std::cerr << "Time: " << step.time_ << " Pos: " << step.path_pos_ << "  vel: " << step.path_vel_ << std::endl;
   }
 }
 
@@ -518,7 +506,6 @@ bool Trajectory::getNextVelocitySwitchingPoint(double path_pos, TrajectoryStep& 
 // Returns true if end of path is reached
 bool Trajectory::integrateForward(std::list<TrajectoryStep>& trajectory, double acceleration)
 {
-  std::cerr << "DOING integrateForward" << std::endl;
   double path_pos = trajectory.back().path_pos_;
   double path_vel = trajectory.back().path_vel_;
 
@@ -531,7 +518,6 @@ bool Trajectory::integrateForward(std::list<TrajectoryStep>& trajectory, double 
            (next_discontinuity->first <= path_pos || !next_discontinuity->second))
     {
       ++next_discontinuity;
-      std::cerr << "++next_discontinuity" << std::endl;
     }
 
     double old_path_pos = path_pos;
@@ -539,18 +525,13 @@ bool Trajectory::integrateForward(std::list<TrajectoryStep>& trajectory, double 
 
     path_vel += time_step_ * acceleration;
     path_pos += time_step_ * 0.5 * (old_path_vel + path_vel);
-    std::cerr << "path_pos: " << path_pos << "  path_vel: " << path_vel << std::endl;
-    // TODO(andyz): path_vel slightly exceeds the maximum here. Clip it?
 
     if (next_discontinuity != switching_points.end() && path_pos > next_discontinuity->first)
     {
-      std::cerr << "Not at the last switching point" << std::endl;
-
       // Avoid having a TrajectoryStep with path_pos near a switching point which will cause an almost identical
       // TrajectoryStep get added in the next run (https://github.com/ros-planning/moveit/issues/1665)
       if (path_pos - next_discontinuity->first < EPS)
       {
-        std::cerr << "Too near switching point. Skipping it" << std::endl;
         continue;
       }
       path_vel = old_path_vel +
@@ -560,7 +541,6 @@ bool Trajectory::integrateForward(std::list<TrajectoryStep>& trajectory, double 
 
     if (path_pos > path_.getLength())
     {
-      std::cerr << "Returning b/c we were able to integrate forward to the end of the path" << std::endl;
       trajectory.push_back(TrajectoryStep(path_pos, path_vel));
       return true;
     }
@@ -643,7 +623,6 @@ bool Trajectory::integrateForward(std::list<TrajectoryStep>& trajectory, double 
 void Trajectory::integrateBackward(std::list<TrajectoryStep>& start_trajectory, double path_pos, double path_vel,
                                    double acceleration)
 {
-  std::cerr << "Integrating b/w" << std::endl;
   std::list<TrajectoryStep>::iterator start2 = start_trajectory.end();
   --start2;
   std::list<TrajectoryStep>::iterator start1 = start2;
@@ -659,9 +638,6 @@ void Trajectory::integrateBackward(std::list<TrajectoryStep>& start_trajectory, 
       trajectory.push_front(TrajectoryStep(path_pos, path_vel));
       path_vel -= time_step_ * acceleration;
       path_pos -= time_step_ * 0.5 * (path_vel + trajectory.front().path_vel_);
-
-      std::cerr << "path_pos: " << path_pos << "  path_vel: " << path_vel << std::endl;
-
       acceleration = getMinMaxPathAcceleration(path_pos, path_vel, false);
       slope = (trajectory.front().path_vel_ - path_vel) / (trajectory.front().path_pos_ - path_pos);
 
@@ -875,7 +851,6 @@ Eigen::VectorXd Trajectory::getAcceleration(double time) const
       (path_.getTangent(path_pos) * path_vel - path_.getTangent(previous->path_pos_) * previous->path_vel_);
   if (time_step > 0.0)
     path_acc /= time_step;
-  std::cerr << "Getting acceleration: " << acceleration << " vector: " << path_acc[0] << std::endl;
   return path_acc;
 }
 

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -868,7 +868,6 @@ Eigen::VectorXd Trajectory::getAcceleration(double time) const
   const double acceleration =
       2.0 * (it->path_pos_ - previous->path_pos_ - time_step * previous->path_vel_) / (time_step * time_step);
 
-  time_step = time - previous->time_;
   const double path_pos =
       previous->path_pos_ + time_step * previous->path_vel_ + 0.5 * time_step * time_step * acceleration;
   const double path_vel = previous->path_vel_ + time_step * acceleration;
@@ -876,6 +875,7 @@ Eigen::VectorXd Trajectory::getAcceleration(double time) const
       (path_.getTangent(path_pos) * path_vel - path_.getTangent(previous->path_pos_) * previous->path_vel_);
   if (time_step > 0.0)
     path_acc /= time_step;
+  std::cerr << "Getting acceleration: " << acceleration << " vector: " << path_acc[0] << std::endl;
   return path_acc;
 }
 

--- a/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/src/time_optimal_trajectory_generation.cpp
@@ -826,7 +826,6 @@ Eigen::VectorXd Trajectory::getVelocity(double time) const
   const double acceleration =
       2.0 * (it->path_pos_ - previous->path_pos_ - time_step * previous->path_vel_) / (time_step * time_step);
 
-  time_step = time - previous->time_;
   const double path_pos =
       previous->path_pos_ + time_step * previous->path_vel_ + 0.5 * time_step * time_step * acceleration;
   const double path_vel = previous->path_vel_ + time_step * acceleration;

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -44,308 +44,356 @@ using trajectory_processing::Path;
 using trajectory_processing::TimeOptimalTrajectoryGeneration;
 using trajectory_processing::Trajectory;
 
-TEST(time_optimal_trajectory_generation, test1)
+// TEST(time_optimal_trajectory_generation, test1)
+// {
+//   Eigen::VectorXd waypoint(4);
+//   std::list<Eigen::VectorXd> waypoints;
+
+//   waypoint << 1424.0, 984.999694824219, 2126.0, 0.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 1423.0, 985.000244140625, 2126.0, 0.0;
+//   waypoints.push_back(waypoint);
+
+//   Eigen::VectorXd max_velocities(4);
+//   max_velocities << 1.3, 0.67, 0.67, 0.5;
+//   Eigen::VectorXd max_accelerations(4);
+//   max_accelerations << 0.00249, 0.00249, 0.00249, 0.00249;
+
+//   Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations, 10.0);
+//   EXPECT_TRUE(trajectory.isValid());
+//   EXPECT_DOUBLE_EQ(40.080256821829849, trajectory.getDuration());
+
+//   // Test start matches
+//   EXPECT_DOUBLE_EQ(1424.0, trajectory.getPosition(0.0)[0]);
+//   EXPECT_DOUBLE_EQ(984.999694824219, trajectory.getPosition(0.0)[1]);
+//   EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(0.0)[2]);
+//   EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(0.0)[3]);
+
+//   // Test end matches
+//   EXPECT_DOUBLE_EQ(1423.0, trajectory.getPosition(trajectory.getDuration())[0]);
+//   EXPECT_DOUBLE_EQ(985.000244140625, trajectory.getPosition(trajectory.getDuration())[1]);
+//   EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(trajectory.getDuration())[2]);
+//   EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(trajectory.getDuration())[3]);
+// }
+
+// TEST(time_optimal_trajectory_generation, test2)
+// {
+//   Eigen::VectorXd waypoint(4);
+//   std::list<Eigen::VectorXd> waypoints;
+
+//   waypoint << 1427.0, 368.0, 690.0, 90.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 1427.0, 368.0, 790.0, 90.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 452.5, 533.0, 1051.0, 90.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 452.5, 533.0, 951.0, 90.0;
+//   waypoints.push_back(waypoint);
+
+//   Eigen::VectorXd max_velocities(4);
+//   max_velocities << 1.3, 0.67, 0.67, 0.5;
+//   Eigen::VectorXd max_accelerations(4);
+//   max_accelerations << 0.002, 0.002, 0.002, 0.002;
+
+//   Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations, 10.0);
+//   EXPECT_TRUE(trajectory.isValid());
+//   EXPECT_DOUBLE_EQ(1922.1418427445944, trajectory.getDuration());
+
+//   // Test start matches
+//   EXPECT_DOUBLE_EQ(1427.0, trajectory.getPosition(0.0)[0]);
+//   EXPECT_DOUBLE_EQ(368.0, trajectory.getPosition(0.0)[1]);
+//   EXPECT_DOUBLE_EQ(690.0, trajectory.getPosition(0.0)[2]);
+//   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(0.0)[3]);
+
+//   // Test end matches
+//   EXPECT_DOUBLE_EQ(452.5, trajectory.getPosition(trajectory.getDuration())[0]);
+//   EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
+//   EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
+//   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
+// }
+
+// TEST(time_optimal_trajectory_generation, test3)
+// {
+//   Eigen::VectorXd waypoint(4);
+//   std::list<Eigen::VectorXd> waypoints;
+
+//   waypoint << 1427.0, 368.0, 690.0, 90.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 1427.0, 368.0, 790.0, 90.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 452.5, 533.0, 1051.0, 90.0;
+//   waypoints.push_back(waypoint);
+//   waypoint << 452.5, 533.0, 951.0, 90.0;
+//   waypoints.push_back(waypoint);
+
+//   Eigen::VectorXd max_velocities(4);
+//   max_velocities << 1.3, 0.67, 0.67, 0.5;
+//   Eigen::VectorXd max_accelerations(4);
+//   max_accelerations << 0.002, 0.002, 0.002, 0.002;
+
+//   Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations);
+//   EXPECT_TRUE(trajectory.isValid());
+//   EXPECT_DOUBLE_EQ(1919.5597888812974, trajectory.getDuration());
+
+//   // Test start matches
+//   EXPECT_DOUBLE_EQ(1427.0, trajectory.getPosition(0.0)[0]);
+//   EXPECT_DOUBLE_EQ(368.0, trajectory.getPosition(0.0)[1]);
+//   EXPECT_DOUBLE_EQ(690.0, trajectory.getPosition(0.0)[2]);
+//   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(0.0)[3]);
+
+//   // Test end matches
+//   EXPECT_DOUBLE_EQ(452.5, trajectory.getPosition(trajectory.getDuration())[0]);
+//   EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
+//   EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
+//   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
+// }
+
+// // Test that totg algorithm doesn't give large acceleration
+// TEST(time_optimal_trajectory_generation, testLargeAccel)
+// {
+//   double path_tolerance = 0.1;
+//   double resample_dt = 0.1;
+//   Eigen::VectorXd waypoint(6);
+//   std::list<Eigen::VectorXd> waypoints;
+//   Eigen::VectorXd max_velocities(6);
+//   Eigen::VectorXd max_accelerations(6);
+
+//   // Waypoints
+//   // clang-format off
+//   waypoint << 1.6113056281076339,
+//              -0.21400163389235427,
+//              -1.974502599739185,
+//               9.9653618690354051e-12,
+//              -1.3810916877429624,
+//               1.5293902838041467;
+//   waypoints.push_back(waypoint);
+
+//   waypoint << 1.6088016187976597,
+//              -0.21792862470933924,
+//              -1.9758628799742952,
+//               0.00010424017303217738,
+//              -1.3835690515335755,
+//               1.5279972853269816;
+//   waypoints.push_back(waypoint);
+
+//   waypoint << 1.5887695443178671,
+//              -0.24934455124521923,
+//              -1.9867451218551782,
+//               0.00093816147756670078,
+//              -1.4033879618584812,
+//               1.5168532975096607;
+//   waypoints.push_back(waypoint);
+
+//   waypoint << 1.1647412393815282,
+//              -0.91434018564402375,
+//              -2.2170946337498498,
+//               0.018590164397622583,
+//              -1.8229041212673529,
+//               1.2809632867583278;
+//   waypoints.push_back(waypoint);
+
+//   // Max velocities
+//   max_velocities << 0.89535390627300004,
+//                     0.89535390627300004,
+//                     0.79587013890930003,
+//                     0.92022484811399996,
+//                     0.82074108075029995,
+//                     1.3927727430915;
+//   // Max accelerations
+//   max_accelerations << 0.82673490883799994,
+//                        0.78539816339699997,
+//                        0.60883578557700002,
+//                        3.2074759432319997,
+//                        1.4398966328939999,
+//                        4.7292792634680003;
+//   // clang-format on
+
+//   Trajectory parameterized(Path(waypoints, path_tolerance), max_velocities, max_accelerations, 0.001);
+
+//   ASSERT_TRUE(parameterized.isValid());
+
+//   size_t sample_count = std::ceil(parameterized.getDuration() / resample_dt);
+//   for (size_t sample = 0; sample <= sample_count; ++sample)
+//   {
+//     // always sample the end of the trajectory as well
+//     double t = std::min(parameterized.getDuration(), sample * resample_dt);
+//     Eigen::VectorXd acceleration = parameterized.getAcceleration(t);
+
+//     ASSERT_EQ(acceleration.size(), 6);
+//     for (std::size_t i = 0; i < 6; ++i)
+//       EXPECT_NEAR(acceleration(i), 0.0, 100.0) << "Invalid acceleration at position " << sample_count << "\n";
+//   }
+// }
+
+// TEST(time_optimal_trajectory_generation, testPluginAPI)
+// {
+//   constexpr auto robot_name{ "panda" };
+//   constexpr auto group_name{ "panda_arm" };
+
+//   auto robot_model = moveit::core::loadTestingRobotModel(robot_name);
+//   ASSERT_TRUE((bool)robot_model) << "Failed to load robot model" << robot_name;
+//   auto group = robot_model->getJointModelGroup(group_name);
+//   ASSERT_TRUE((bool)group) << "Failed to load joint model group " << group_name;
+//   moveit::core::RobotState waypoint_state(robot_model);
+//   waypoint_state.setToDefaultValues();
+
+//   robot_trajectory::RobotTrajectory trajectory(robot_model, group);
+//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
+//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
+//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
+//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
+//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
+//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
+//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+
+//   // Number TOTG iterations
+//   constexpr size_t totg_iterations = 10;
+
+//   // Test computing the dynamics repeatedly with the same totg instance
+//   moveit_msgs::RobotTrajectory first_trajectory_msg_start, first_trajectory_msg_end;
+//   {
+//     robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
+
+//     // Test if the trajectory was copied correctly
+//     ASSERT_EQ(test_trajectory.getDuration(), trajectory.getDuration());
+//     moveit::core::JointBoundsVector test_bounds = test_trajectory.getRobotModel()->getActiveJointModelsBounds();
+//     moveit::core::JointBoundsVector original_bounds = trajectory.getRobotModel()->getActiveJointModelsBounds();
+//     ASSERT_EQ(test_bounds.size(), original_bounds.size());
+//     for (size_t bound_idx = 0; bound_idx < test_bounds.at(0)->size(); ++bound_idx)
+//     {
+//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).max_velocity_, original_bounds.at(0)->at(bound_idx).max_velocity_);
+//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).min_velocity_, original_bounds.at(0)->at(bound_idx).min_velocity_);
+//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).velocity_bounded_,
+//                 original_bounds.at(0)->at(bound_idx).velocity_bounded_);
+
+//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).max_acceleration_,
+//                 original_bounds.at(0)->at(bound_idx).max_acceleration_);
+//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).min_acceleration_,
+//                 original_bounds.at(0)->at(bound_idx).min_acceleration_);
+//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).acceleration_bounded_,
+//                 original_bounds.at(0)->at(bound_idx).acceleration_bounded_);
+//     }
+//     ASSERT_EQ(test_trajectory.getWayPointDurationFromPrevious(1), trajectory.getWayPointDurationFromPrevious(1));
+
+//     TimeOptimalTrajectoryGeneration totg;
+//     ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";
+
+//     test_trajectory.getRobotTrajectoryMsg(first_trajectory_msg_start);
+
+//     // Iteratively recompute timestamps with same totg instance
+//     for (size_t i = 0; i < totg_iterations; ++i)
+//     {
+//       bool totg_success = totg.computeTimeStamps(test_trajectory);
+//       EXPECT_TRUE(totg_success) << "Failed to compute time stamps with a same TOTG instance in iteration " << i;
+//     }
+
+//     test_trajectory.getRobotTrajectoryMsg(first_trajectory_msg_end);
+//   }
+
+//   // Test computing the dynamics repeatedly with one TOTG instance per call
+//   moveit_msgs::RobotTrajectory second_trajectory_msg_start, second_trajectory_msg_end;
+//   {
+//     robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
+
+//     {
+//       TimeOptimalTrajectoryGeneration totg;
+//       ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";
+//     }
+
+//     test_trajectory.getRobotTrajectoryMsg(second_trajectory_msg_start);
+
+//     // Iteratively recompute timestamps with new totg instances
+//     for (size_t i = 0; i < totg_iterations; ++i)
+//     {
+//       TimeOptimalTrajectoryGeneration totg;
+//       bool totg_success = totg.computeTimeStamps(test_trajectory);
+//       EXPECT_TRUE(totg_success) << "Failed to compute time stamps with a new TOTG instance in iteration " << i;
+//     }
+
+//     test_trajectory.getRobotTrajectoryMsg(second_trajectory_msg_end);
+//   }
+
+//   // Make sure trajectories produce equal waypoints independent of TOTG instances
+//   ASSERT_EQ(first_trajectory_msg_start, second_trajectory_msg_start);
+//   ASSERT_EQ(first_trajectory_msg_end, second_trajectory_msg_end);
+
+//   // Iterate on the original trajectory again
+//   moveit_msgs::RobotTrajectory third_trajectory_msg_end;
+
+//   {
+//     TimeOptimalTrajectoryGeneration totg;
+//     ASSERT_TRUE(totg.computeTimeStamps(trajectory)) << "Failed to compute time stamps";
+//   }
+
+//   for (size_t i = 0; i < totg_iterations; ++i)
+//   {
+//     TimeOptimalTrajectoryGeneration totg;
+//     bool totg_success = totg.computeTimeStamps(trajectory);
+//     ASSERT_TRUE(totg_success) << "Failed to compute timestamps on a new TOTG instance in iteration " << i;
+//   }
+
+//   // Compare with previous work
+//   trajectory.getRobotTrajectoryMsg(third_trajectory_msg_end);
+
+//   // Make sure trajectories produce equal waypoints independent of TOTG instances
+//   ASSERT_EQ(first_trajectory_msg_end, third_trajectory_msg_end);
+// }
+
+TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
 {
-  Eigen::VectorXd waypoint(4);
+  // Test a (prior) specific failure case
+  Eigen::VectorXd waypoint(1);
   std::list<Eigen::VectorXd> waypoints;
 
-  waypoint << 1424.0, 984.999694824219, 2126.0, 0.0;
+  const double start_position = 1.881943;
+  waypoint << start_position;
   waypoints.push_back(waypoint);
-  waypoint << 1423.0, 985.000244140625, 2126.0, 0.0;
+  waypoint << 2.600542;
   waypoints.push_back(waypoint);
 
-  Eigen::VectorXd max_velocities(4);
-  max_velocities << 1.3, 0.67, 0.67, 0.5;
-  Eigen::VectorXd max_accelerations(4);
-  max_accelerations << 0.00249, 0.00249, 0.00249, 0.00249;
+  Eigen::VectorXd max_velocities(1);
+  max_velocities << 4.54;
+  Eigen::VectorXd max_accelerations(1);
+  max_accelerations << 28.0;
 
-  Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations, 10.0);
+  Trajectory trajectory(Path(waypoints, 0.1 /* path tolerance */), max_velocities, max_accelerations,
+                        0.001 /* timestep */);
   EXPECT_TRUE(trajectory.isValid());
-  EXPECT_DOUBLE_EQ(40.080256821829849, trajectory.getDuration());
 
-  // Test start matches
-  EXPECT_DOUBLE_EQ(1424.0, trajectory.getPosition(0.0)[0]);
-  EXPECT_DOUBLE_EQ(984.999694824219, trajectory.getPosition(0.0)[1]);
-  EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(0.0)[2]);
-  EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(0.0)[3]);
+  EXPECT_GT(trajectory.getDuration(), 0.0);
+  const double traj_duration = trajectory.getDuration();
+  EXPECT_NEAR(0.320681, traj_duration, 1e-3);
 
-  // Test end matches
-  EXPECT_DOUBLE_EQ(1423.0, trajectory.getPosition(trajectory.getDuration())[0]);
-  EXPECT_DOUBLE_EQ(985.000244140625, trajectory.getPosition(trajectory.getDuration())[1]);
-  EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(trajectory.getDuration())[2]);
-  EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(trajectory.getDuration())[3]);
-}
+  // Start matches
+  EXPECT_DOUBLE_EQ(start_position, trajectory.getPosition(0.0)[0]);
 
-TEST(time_optimal_trajectory_generation, test2)
-{
-  Eigen::VectorXd waypoint(4);
-  std::list<Eigen::VectorXd> waypoints;
-
-  waypoint << 1427.0, 368.0, 690.0, 90.0;
-  waypoints.push_back(waypoint);
-  waypoint << 1427.0, 368.0, 790.0, 90.0;
-  waypoints.push_back(waypoint);
-  waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
-  waypoints.push_back(waypoint);
-  waypoint << 452.5, 533.0, 1051.0, 90.0;
-  waypoints.push_back(waypoint);
-  waypoint << 452.5, 533.0, 951.0, 90.0;
-  waypoints.push_back(waypoint);
-
-  Eigen::VectorXd max_velocities(4);
-  max_velocities << 1.3, 0.67, 0.67, 0.5;
-  Eigen::VectorXd max_accelerations(4);
-  max_accelerations << 0.002, 0.002, 0.002, 0.002;
-
-  Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations, 10.0);
-  EXPECT_TRUE(trajectory.isValid());
-  EXPECT_DOUBLE_EQ(1922.1418427445944, trajectory.getDuration());
-
-  // Test start matches
-  EXPECT_DOUBLE_EQ(1427.0, trajectory.getPosition(0.0)[0]);
-  EXPECT_DOUBLE_EQ(368.0, trajectory.getPosition(0.0)[1]);
-  EXPECT_DOUBLE_EQ(690.0, trajectory.getPosition(0.0)[2]);
-  EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(0.0)[3]);
-
-  // Test end matches
-  EXPECT_DOUBLE_EQ(452.5, trajectory.getPosition(trajectory.getDuration())[0]);
-  EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
-  EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
-  EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
-}
-
-TEST(time_optimal_trajectory_generation, test3)
-{
-  Eigen::VectorXd waypoint(4);
-  std::list<Eigen::VectorXd> waypoints;
-
-  waypoint << 1427.0, 368.0, 690.0, 90.0;
-  waypoints.push_back(waypoint);
-  waypoint << 1427.0, 368.0, 790.0, 90.0;
-  waypoints.push_back(waypoint);
-  waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
-  waypoints.push_back(waypoint);
-  waypoint << 452.5, 533.0, 1051.0, 90.0;
-  waypoints.push_back(waypoint);
-  waypoint << 452.5, 533.0, 951.0, 90.0;
-  waypoints.push_back(waypoint);
-
-  Eigen::VectorXd max_velocities(4);
-  max_velocities << 1.3, 0.67, 0.67, 0.5;
-  Eigen::VectorXd max_accelerations(4);
-  max_accelerations << 0.002, 0.002, 0.002, 0.002;
-
-  Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations);
-  EXPECT_TRUE(trajectory.isValid());
-  EXPECT_DOUBLE_EQ(1919.5597888812974, trajectory.getDuration());
-
-  // Test start matches
-  EXPECT_DOUBLE_EQ(1427.0, trajectory.getPosition(0.0)[0]);
-  EXPECT_DOUBLE_EQ(368.0, trajectory.getPosition(0.0)[1]);
-  EXPECT_DOUBLE_EQ(690.0, trajectory.getPosition(0.0)[2]);
-  EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(0.0)[3]);
-
-  // Test end matches
-  EXPECT_DOUBLE_EQ(452.5, trajectory.getPosition(trajectory.getDuration())[0]);
-  EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
-  EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
-  EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
-}
-
-// Test that totg algorithm doesn't give large acceleration
-TEST(time_optimal_trajectory_generation, testLargeAccel)
-{
-  double path_tolerance = 0.1;
-  double resample_dt = 0.1;
-  Eigen::VectorXd waypoint(6);
-  std::list<Eigen::VectorXd> waypoints;
-  Eigen::VectorXd max_velocities(6);
-  Eigen::VectorXd max_accelerations(6);
-
-  // Waypoints
-  // clang-format off
-  waypoint << 1.6113056281076339,
-             -0.21400163389235427,
-             -1.974502599739185,
-              9.9653618690354051e-12,
-             -1.3810916877429624,
-              1.5293902838041467;
-  waypoints.push_back(waypoint);
-
-  waypoint << 1.6088016187976597,
-             -0.21792862470933924,
-             -1.9758628799742952,
-              0.00010424017303217738,
-             -1.3835690515335755,
-              1.5279972853269816;
-  waypoints.push_back(waypoint);
-
-  waypoint << 1.5887695443178671,
-             -0.24934455124521923,
-             -1.9867451218551782,
-              0.00093816147756670078,
-             -1.4033879618584812,
-              1.5168532975096607;
-  waypoints.push_back(waypoint);
-
-  waypoint << 1.1647412393815282,
-             -0.91434018564402375,
-             -2.2170946337498498,
-              0.018590164397622583,
-             -1.8229041212673529,
-              1.2809632867583278;
-  waypoints.push_back(waypoint);
-
-  // Max velocities
-  max_velocities << 0.89535390627300004,
-                    0.89535390627300004,
-                    0.79587013890930003,
-                    0.92022484811399996,
-                    0.82074108075029995,
-                    1.3927727430915;
-  // Max accelerations
-  max_accelerations << 0.82673490883799994,
-                       0.78539816339699997,
-                       0.60883578557700002,
-                       3.2074759432319997,
-                       1.4398966328939999,
-                       4.7292792634680003;
-  // clang-format on
-
-  Trajectory parameterized(Path(waypoints, path_tolerance), max_velocities, max_accelerations, 0.001);
-
-  ASSERT_TRUE(parameterized.isValid());
-
-  size_t sample_count = std::ceil(parameterized.getDuration() / resample_dt);
-  for (size_t sample = 0; sample <= sample_count; ++sample)
+  // Check vels and accels at all points
+  for (double time = 0; time < traj_duration; time += 0.01)
   {
-    // always sample the end of the trajectory as well
-    double t = std::min(parameterized.getDuration(), sample * resample_dt);
-    Eigen::VectorXd acceleration = parameterized.getAcceleration(t);
-
-    ASSERT_EQ(acceleration.size(), 6);
-    for (std::size_t i = 0; i < 6; ++i)
-      EXPECT_NEAR(acceleration(i), 0.0, 100.0) << "Invalid acceleration at position " << sample_count << "\n";
-  }
-}
-
-TEST(time_optimal_trajectory_generation, testPluginAPI)
-{
-  constexpr auto robot_name{ "panda" };
-  constexpr auto group_name{ "panda_arm" };
-
-  auto robot_model = moveit::core::loadTestingRobotModel(robot_name);
-  ASSERT_TRUE((bool)robot_model) << "Failed to load robot model" << robot_name;
-  auto group = robot_model->getJointModelGroup(group_name);
-  ASSERT_TRUE((bool)group) << "Failed to load joint model group " << group_name;
-  moveit::core::RobotState waypoint_state(robot_model);
-  waypoint_state.setToDefaultValues();
-
-  robot_trajectory::RobotTrajectory trajectory(robot_model, group);
-  waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-  waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-  waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-  waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-  waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-  waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-
-  // Number TOTG iterations
-  constexpr size_t totg_iterations = 10;
-
-  // Test computing the dynamics repeatedly with the same totg instance
-  moveit_msgs::RobotTrajectory first_trajectory_msg_start, first_trajectory_msg_end;
-  {
-    robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
-
-    // Test if the trajectory was copied correctly
-    ASSERT_EQ(test_trajectory.getDuration(), trajectory.getDuration());
-    moveit::core::JointBoundsVector test_bounds = test_trajectory.getRobotModel()->getActiveJointModelsBounds();
-    moveit::core::JointBoundsVector original_bounds = trajectory.getRobotModel()->getActiveJointModelsBounds();
-    ASSERT_EQ(test_bounds.size(), original_bounds.size());
-    for (size_t bound_idx = 0; bound_idx < test_bounds.at(0)->size(); ++bound_idx)
+    // This trajectory has a single switching point
+    double t_switch = 0.1603407;
+    if (time == 0)
     {
-      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).max_velocity_, original_bounds.at(0)->at(bound_idx).max_velocity_);
-      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).min_velocity_, original_bounds.at(0)->at(bound_idx).min_velocity_);
-      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).velocity_bounded_,
-                original_bounds.at(0)->at(bound_idx).velocity_bounded_);
-
-      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).max_acceleration_,
-                original_bounds.at(0)->at(bound_idx).max_acceleration_);
-      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).min_acceleration_,
-                original_bounds.at(0)->at(bound_idx).min_acceleration_);
-      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).acceleration_bounded_,
-                original_bounds.at(0)->at(bound_idx).acceleration_bounded_);
+      EXPECT_NEAR(trajectory.getAcceleration(time)[0], 0, 1e-3) << "Time: " << time;
     }
-    ASSERT_EQ(test_trajectory.getWayPointDurationFromPrevious(1), trajectory.getWayPointDurationFromPrevious(1));
-
-    TimeOptimalTrajectoryGeneration totg;
-    ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";
-
-    test_trajectory.getRobotTrajectoryMsg(first_trajectory_msg_start);
-
-    // Iteratively recompute timestamps with same totg instance
-    for (size_t i = 0; i < totg_iterations; ++i)
+    else if (time > 0 && time < t_switch)
     {
-      bool totg_success = totg.computeTimeStamps(test_trajectory);
-      EXPECT_TRUE(totg_success) << "Failed to compute time stamps with a same TOTG instance in iteration " << i;
+      EXPECT_NEAR(trajectory.getAcceleration(time)[0], max_accelerations[0], 1e-3) << "Time: " << time;
     }
-
-    test_trajectory.getRobotTrajectoryMsg(first_trajectory_msg_end);
-  }
-
-  // Test computing the dynamics repeatedly with one TOTG instance per call
-  moveit_msgs::RobotTrajectory second_trajectory_msg_start, second_trajectory_msg_end;
-  {
-    robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
-
+    else if (time > t_switch)
     {
-      TimeOptimalTrajectoryGeneration totg;
-      ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";
+      EXPECT_NEAR(trajectory.getAcceleration(time)[0], -max_accelerations[0], 1e-3) << "Time: " << time;
     }
-
-    test_trajectory.getRobotTrajectoryMsg(second_trajectory_msg_start);
-
-    // Iteratively recompute timestamps with new totg instances
-    for (size_t i = 0; i < totg_iterations; ++i)
-    {
-      TimeOptimalTrajectoryGeneration totg;
-      bool totg_success = totg.computeTimeStamps(test_trajectory);
-      EXPECT_TRUE(totg_success) << "Failed to compute time stamps with a new TOTG instance in iteration " << i;
-    }
-
-    test_trajectory.getRobotTrajectoryMsg(second_trajectory_msg_end);
   }
-
-  // Make sure trajectories produce equal waypoints independent of TOTG instances
-  ASSERT_EQ(first_trajectory_msg_start, second_trajectory_msg_start);
-  ASSERT_EQ(first_trajectory_msg_end, second_trajectory_msg_end);
-
-  // Iterate on the original trajectory again
-  moveit_msgs::RobotTrajectory third_trajectory_msg_end;
-
-  {
-    TimeOptimalTrajectoryGeneration totg;
-    ASSERT_TRUE(totg.computeTimeStamps(trajectory)) << "Failed to compute time stamps";
-  }
-
-  for (size_t i = 0; i < totg_iterations; ++i)
-  {
-    TimeOptimalTrajectoryGeneration totg;
-    bool totg_success = totg.computeTimeStamps(trajectory);
-    ASSERT_TRUE(totg_success) << "Failed to compute timestamps on a new TOTG instance in iteration " << i;
-  }
-
-  // Compare with previous work
-  trajectory.getRobotTrajectoryMsg(third_trajectory_msg_end);
-
-  // Make sure trajectories produce equal waypoints independent of TOTG instances
-  ASSERT_EQ(first_trajectory_msg_end, third_trajectory_msg_end);
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -48,309 +48,309 @@ using trajectory_processing::Path;
 using trajectory_processing::TimeOptimalTrajectoryGeneration;
 using trajectory_processing::Trajectory;
 
-// TEST(time_optimal_trajectory_generation, test1)
-// {
-//   Eigen::VectorXd waypoint(4);
-//   std::list<Eigen::VectorXd> waypoints;
+TEST(time_optimal_trajectory_generation, test1)
+{
+  Eigen::VectorXd waypoint(4);
+  std::list<Eigen::VectorXd> waypoints;
 
-//   waypoint << 1424.0, 984.999694824219, 2126.0, 0.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 1423.0, 985.000244140625, 2126.0, 0.0;
-//   waypoints.push_back(waypoint);
+  waypoint << 1424.0, 984.999694824219, 2126.0, 0.0;
+  waypoints.push_back(waypoint);
+  waypoint << 1423.0, 985.000244140625, 2126.0, 0.0;
+  waypoints.push_back(waypoint);
 
-//   Eigen::VectorXd max_velocities(4);
-//   max_velocities << 1.3, 0.67, 0.67, 0.5;
-//   Eigen::VectorXd max_accelerations(4);
-//   max_accelerations << 0.00249, 0.00249, 0.00249, 0.00249;
+  Eigen::VectorXd max_velocities(4);
+  max_velocities << 1.3, 0.67, 0.67, 0.5;
+  Eigen::VectorXd max_accelerations(4);
+  max_accelerations << 0.00249, 0.00249, 0.00249, 0.00249;
 
-//   Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations, 10.0);
-//   EXPECT_TRUE(trajectory.isValid());
-//   EXPECT_DOUBLE_EQ(40.080256821829849, trajectory.getDuration());
+  Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations, 10.0);
+  EXPECT_TRUE(trajectory.isValid());
+  EXPECT_DOUBLE_EQ(40.080256821829849, trajectory.getDuration());
 
-//   // Test start matches
-//   EXPECT_DOUBLE_EQ(1424.0, trajectory.getPosition(0.0)[0]);
-//   EXPECT_DOUBLE_EQ(984.999694824219, trajectory.getPosition(0.0)[1]);
-//   EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(0.0)[2]);
-//   EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(0.0)[3]);
+  // Test start matches
+  EXPECT_DOUBLE_EQ(1424.0, trajectory.getPosition(0.0)[0]);
+  EXPECT_DOUBLE_EQ(984.999694824219, trajectory.getPosition(0.0)[1]);
+  EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(0.0)[2]);
+  EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(0.0)[3]);
 
-//   // Test end matches
-//   EXPECT_DOUBLE_EQ(1423.0, trajectory.getPosition(trajectory.getDuration())[0]);
-//   EXPECT_DOUBLE_EQ(985.000244140625, trajectory.getPosition(trajectory.getDuration())[1]);
-//   EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(trajectory.getDuration())[2]);
-//   EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(trajectory.getDuration())[3]);
-// }
+  // Test end matches
+  EXPECT_DOUBLE_EQ(1423.0, trajectory.getPosition(trajectory.getDuration())[0]);
+  EXPECT_DOUBLE_EQ(985.000244140625, trajectory.getPosition(trajectory.getDuration())[1]);
+  EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(trajectory.getDuration())[2]);
+  EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(trajectory.getDuration())[3]);
+}
 
-// TEST(time_optimal_trajectory_generation, test2)
-// {
-//   Eigen::VectorXd waypoint(4);
-//   std::list<Eigen::VectorXd> waypoints;
+TEST(time_optimal_trajectory_generation, test2)
+{
+  Eigen::VectorXd waypoint(4);
+  std::list<Eigen::VectorXd> waypoints;
 
-//   waypoint << 1427.0, 368.0, 690.0, 90.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 1427.0, 368.0, 790.0, 90.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 452.5, 533.0, 1051.0, 90.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 452.5, 533.0, 951.0, 90.0;
-//   waypoints.push_back(waypoint);
+  waypoint << 1427.0, 368.0, 690.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 1427.0, 368.0, 790.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 452.5, 533.0, 1051.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 452.5, 533.0, 951.0, 90.0;
+  waypoints.push_back(waypoint);
 
-//   Eigen::VectorXd max_velocities(4);
-//   max_velocities << 1.3, 0.67, 0.67, 0.5;
-//   Eigen::VectorXd max_accelerations(4);
-//   max_accelerations << 0.002, 0.002, 0.002, 0.002;
+  Eigen::VectorXd max_velocities(4);
+  max_velocities << 1.3, 0.67, 0.67, 0.5;
+  Eigen::VectorXd max_accelerations(4);
+  max_accelerations << 0.002, 0.002, 0.002, 0.002;
 
-//   Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations, 10.0);
-//   EXPECT_TRUE(trajectory.isValid());
-//   EXPECT_DOUBLE_EQ(1922.1418427445944, trajectory.getDuration());
+  Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations, 10.0);
+  EXPECT_TRUE(trajectory.isValid());
+  EXPECT_DOUBLE_EQ(1922.1418427445944, trajectory.getDuration());
 
-//   // Test start matches
-//   EXPECT_DOUBLE_EQ(1427.0, trajectory.getPosition(0.0)[0]);
-//   EXPECT_DOUBLE_EQ(368.0, trajectory.getPosition(0.0)[1]);
-//   EXPECT_DOUBLE_EQ(690.0, trajectory.getPosition(0.0)[2]);
-//   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(0.0)[3]);
+  // Test start matches
+  EXPECT_DOUBLE_EQ(1427.0, trajectory.getPosition(0.0)[0]);
+  EXPECT_DOUBLE_EQ(368.0, trajectory.getPosition(0.0)[1]);
+  EXPECT_DOUBLE_EQ(690.0, trajectory.getPosition(0.0)[2]);
+  EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(0.0)[3]);
 
-//   // Test end matches
-//   EXPECT_DOUBLE_EQ(452.5, trajectory.getPosition(trajectory.getDuration())[0]);
-//   EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
-//   EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
-//   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
-// }
+  // Test end matches
+  EXPECT_DOUBLE_EQ(452.5, trajectory.getPosition(trajectory.getDuration())[0]);
+  EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
+  EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
+  EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
+}
 
-// TEST(time_optimal_trajectory_generation, test3)
-// {
-//   Eigen::VectorXd waypoint(4);
-//   std::list<Eigen::VectorXd> waypoints;
+TEST(time_optimal_trajectory_generation, test3)
+{
+  Eigen::VectorXd waypoint(4);
+  std::list<Eigen::VectorXd> waypoints;
 
-//   waypoint << 1427.0, 368.0, 690.0, 90.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 1427.0, 368.0, 790.0, 90.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 452.5, 533.0, 1051.0, 90.0;
-//   waypoints.push_back(waypoint);
-//   waypoint << 452.5, 533.0, 951.0, 90.0;
-//   waypoints.push_back(waypoint);
+  waypoint << 1427.0, 368.0, 690.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 1427.0, 368.0, 790.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 952.499938964844, 433.0, 1051.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 452.5, 533.0, 1051.0, 90.0;
+  waypoints.push_back(waypoint);
+  waypoint << 452.5, 533.0, 951.0, 90.0;
+  waypoints.push_back(waypoint);
 
-//   Eigen::VectorXd max_velocities(4);
-//   max_velocities << 1.3, 0.67, 0.67, 0.5;
-//   Eigen::VectorXd max_accelerations(4);
-//   max_accelerations << 0.002, 0.002, 0.002, 0.002;
+  Eigen::VectorXd max_velocities(4);
+  max_velocities << 1.3, 0.67, 0.67, 0.5;
+  Eigen::VectorXd max_accelerations(4);
+  max_accelerations << 0.002, 0.002, 0.002, 0.002;
 
-//   Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations);
-//   EXPECT_TRUE(trajectory.isValid());
-//   EXPECT_DOUBLE_EQ(1919.5597888812974, trajectory.getDuration());
+  Trajectory trajectory(Path(waypoints, 100.0), max_velocities, max_accelerations);
+  EXPECT_TRUE(trajectory.isValid());
+  EXPECT_DOUBLE_EQ(1919.5597888812974, trajectory.getDuration());
 
-//   // Test start matches
-//   EXPECT_DOUBLE_EQ(1427.0, trajectory.getPosition(0.0)[0]);
-//   EXPECT_DOUBLE_EQ(368.0, trajectory.getPosition(0.0)[1]);
-//   EXPECT_DOUBLE_EQ(690.0, trajectory.getPosition(0.0)[2]);
-//   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(0.0)[3]);
+  // Test start matches
+  EXPECT_DOUBLE_EQ(1427.0, trajectory.getPosition(0.0)[0]);
+  EXPECT_DOUBLE_EQ(368.0, trajectory.getPosition(0.0)[1]);
+  EXPECT_DOUBLE_EQ(690.0, trajectory.getPosition(0.0)[2]);
+  EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(0.0)[3]);
 
-//   // Test end matches
-//   EXPECT_DOUBLE_EQ(452.5, trajectory.getPosition(trajectory.getDuration())[0]);
-//   EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
-//   EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
-//   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
-// }
+  // Test end matches
+  EXPECT_DOUBLE_EQ(452.5, trajectory.getPosition(trajectory.getDuration())[0]);
+  EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
+  EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
+  EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
+}
 
-// // Test that totg algorithm doesn't give large acceleration
-// TEST(time_optimal_trajectory_generation, testLargeAccel)
-// {
-//   double path_tolerance = 0.1;
-//   double resample_dt = 0.1;
-//   Eigen::VectorXd waypoint(6);
-//   std::list<Eigen::VectorXd> waypoints;
-//   Eigen::VectorXd max_velocities(6);
-//   Eigen::VectorXd max_accelerations(6);
+// Test that totg algorithm doesn't give large acceleration
+TEST(time_optimal_trajectory_generation, testLargeAccel)
+{
+  double path_tolerance = 0.1;
+  double resample_dt = 0.1;
+  Eigen::VectorXd waypoint(6);
+  std::list<Eigen::VectorXd> waypoints;
+  Eigen::VectorXd max_velocities(6);
+  Eigen::VectorXd max_accelerations(6);
 
-//   // Waypoints
-//   // clang-format off
-//   waypoint << 1.6113056281076339,
-//              -0.21400163389235427,
-//              -1.974502599739185,
-//               9.9653618690354051e-12,
-//              -1.3810916877429624,
-//               1.5293902838041467;
-//   waypoints.push_back(waypoint);
+  // Waypoints
+  // clang-format off
+  waypoint << 1.6113056281076339,
+             -0.21400163389235427,
+             -1.974502599739185,
+              9.9653618690354051e-12,
+             -1.3810916877429624,
+              1.5293902838041467;
+  waypoints.push_back(waypoint);
 
-//   waypoint << 1.6088016187976597,
-//              -0.21792862470933924,
-//              -1.9758628799742952,
-//               0.00010424017303217738,
-//              -1.3835690515335755,
-//               1.5279972853269816;
-//   waypoints.push_back(waypoint);
+  waypoint << 1.6088016187976597,
+             -0.21792862470933924,
+             -1.9758628799742952,
+              0.00010424017303217738,
+             -1.3835690515335755,
+              1.5279972853269816;
+  waypoints.push_back(waypoint);
 
-//   waypoint << 1.5887695443178671,
-//              -0.24934455124521923,
-//              -1.9867451218551782,
-//               0.00093816147756670078,
-//              -1.4033879618584812,
-//               1.5168532975096607;
-//   waypoints.push_back(waypoint);
+  waypoint << 1.5887695443178671,
+             -0.24934455124521923,
+             -1.9867451218551782,
+              0.00093816147756670078,
+             -1.4033879618584812,
+              1.5168532975096607;
+  waypoints.push_back(waypoint);
 
-//   waypoint << 1.1647412393815282,
-//              -0.91434018564402375,
-//              -2.2170946337498498,
-//               0.018590164397622583,
-//              -1.8229041212673529,
-//               1.2809632867583278;
-//   waypoints.push_back(waypoint);
+  waypoint << 1.1647412393815282,
+             -0.91434018564402375,
+             -2.2170946337498498,
+              0.018590164397622583,
+             -1.8229041212673529,
+              1.2809632867583278;
+  waypoints.push_back(waypoint);
 
-//   // Max velocities
-//   max_velocities << 0.89535390627300004,
-//                     0.89535390627300004,
-//                     0.79587013890930003,
-//                     0.92022484811399996,
-//                     0.82074108075029995,
-//                     1.3927727430915;
-//   // Max accelerations
-//   max_accelerations << 0.82673490883799994,
-//                        0.78539816339699997,
-//                        0.60883578557700002,
-//                        3.2074759432319997,
-//                        1.4398966328939999,
-//                        4.7292792634680003;
-//   // clang-format on
+  // Max velocities
+  max_velocities << 0.89535390627300004,
+                    0.89535390627300004,
+                    0.79587013890930003,
+                    0.92022484811399996,
+                    0.82074108075029995,
+                    1.3927727430915;
+  // Max accelerations
+  max_accelerations << 0.82673490883799994,
+                       0.78539816339699997,
+                       0.60883578557700002,
+                       3.2074759432319997,
+                       1.4398966328939999,
+                       4.7292792634680003;
+  // clang-format on
 
-//   Trajectory parameterized(Path(waypoints, path_tolerance), max_velocities, max_accelerations, 0.001);
+  Trajectory parameterized(Path(waypoints, path_tolerance), max_velocities, max_accelerations, 0.001);
 
-//   ASSERT_TRUE(parameterized.isValid());
+  ASSERT_TRUE(parameterized.isValid());
 
-//   size_t sample_count = std::ceil(parameterized.getDuration() / resample_dt);
-//   for (size_t sample = 0; sample <= sample_count; ++sample)
-//   {
-//     // always sample the end of the trajectory as well
-//     double t = std::min(parameterized.getDuration(), sample * resample_dt);
-//     Eigen::VectorXd acceleration = parameterized.getAcceleration(t);
+  size_t sample_count = std::ceil(parameterized.getDuration() / resample_dt);
+  for (size_t sample = 0; sample <= sample_count; ++sample)
+  {
+    // always sample the end of the trajectory as well
+    double t = std::min(parameterized.getDuration(), sample * resample_dt);
+    Eigen::VectorXd acceleration = parameterized.getAcceleration(t);
 
-//     ASSERT_EQ(acceleration.size(), 6);
-//     for (std::size_t i = 0; i < 6; ++i)
-//       EXPECT_NEAR(acceleration(i), 0.0, 100.0) << "Invalid acceleration at position " << sample_count << "\n";
-//   }
-// }
+    ASSERT_EQ(acceleration.size(), 6);
+    for (std::size_t i = 0; i < 6; ++i)
+      EXPECT_NEAR(acceleration(i), 0.0, 100.0) << "Invalid acceleration at position " << sample_count << "\n";
+  }
+}
 
-// TEST(time_optimal_trajectory_generation, testPluginAPI)
-// {
-//   constexpr auto robot_name{ "panda" };
-//   constexpr auto group_name{ "panda_arm" };
+TEST(time_optimal_trajectory_generation, testPluginAPI)
+{
+  constexpr auto robot_name{ "panda" };
+  constexpr auto group_name{ "panda_arm" };
 
-//   auto robot_model = moveit::core::loadTestingRobotModel(robot_name);
-//   ASSERT_TRUE((bool)robot_model) << "Failed to load robot model" << robot_name;
-//   auto group = robot_model->getJointModelGroup(group_name);
-//   ASSERT_TRUE((bool)group) << "Failed to load joint model group " << group_name;
-//   moveit::core::RobotState waypoint_state(robot_model);
-//   waypoint_state.setToDefaultValues();
+  auto robot_model = moveit::core::loadTestingRobotModel(robot_name);
+  ASSERT_TRUE((bool)robot_model) << "Failed to load robot model" << robot_name;
+  auto group = robot_model->getJointModelGroup(group_name);
+  ASSERT_TRUE((bool)group) << "Failed to load joint model group " << group_name;
+  moveit::core::RobotState waypoint_state(robot_model);
+  waypoint_state.setToDefaultValues();
 
-//   robot_trajectory::RobotTrajectory trajectory(robot_model, group);
-//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
-//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
-//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
-//   waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
-//   trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  robot_trajectory::RobotTrajectory trajectory(robot_model, group);
+  waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
+  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
+  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
+  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
+  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  waypoint_state.setJointGroupPositions(group, std::vector<double>{ 0.0, -3.5, 1.4, -1.2, -1.0, -0.2, 0.0 });
+  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
+  waypoint_state.setJointGroupPositions(group, std::vector<double>{ -0.5, -3.52, 1.35, -2.51, -0.88, 0.63, 0.0 });
+  trajectory.addSuffixWayPoint(waypoint_state, 0.1);
 
-//   // Number TOTG iterations
-//   constexpr size_t totg_iterations = 10;
+  // Number TOTG iterations
+  constexpr size_t totg_iterations = 10;
 
-//   // Test computing the dynamics repeatedly with the same totg instance
-//   moveit_msgs::RobotTrajectory first_trajectory_msg_start, first_trajectory_msg_end;
-//   {
-//     robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
+  // Test computing the dynamics repeatedly with the same totg instance
+  moveit_msgs::RobotTrajectory first_trajectory_msg_start, first_trajectory_msg_end;
+  {
+    robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
 
-//     // Test if the trajectory was copied correctly
-//     ASSERT_EQ(test_trajectory.getDuration(), trajectory.getDuration());
-//     moveit::core::JointBoundsVector test_bounds = test_trajectory.getRobotModel()->getActiveJointModelsBounds();
-//     moveit::core::JointBoundsVector original_bounds = trajectory.getRobotModel()->getActiveJointModelsBounds();
-//     ASSERT_EQ(test_bounds.size(), original_bounds.size());
-//     for (size_t bound_idx = 0; bound_idx < test_bounds.at(0)->size(); ++bound_idx)
-//     {
-//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).max_velocity_, original_bounds.at(0)->at(bound_idx).max_velocity_);
-//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).min_velocity_, original_bounds.at(0)->at(bound_idx).min_velocity_);
-//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).velocity_bounded_,
-//                 original_bounds.at(0)->at(bound_idx).velocity_bounded_);
+    // Test if the trajectory was copied correctly
+    ASSERT_EQ(test_trajectory.getDuration(), trajectory.getDuration());
+    moveit::core::JointBoundsVector test_bounds = test_trajectory.getRobotModel()->getActiveJointModelsBounds();
+    moveit::core::JointBoundsVector original_bounds = trajectory.getRobotModel()->getActiveJointModelsBounds();
+    ASSERT_EQ(test_bounds.size(), original_bounds.size());
+    for (size_t bound_idx = 0; bound_idx < test_bounds.at(0)->size(); ++bound_idx)
+    {
+      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).max_velocity_, original_bounds.at(0)->at(bound_idx).max_velocity_);
+      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).min_velocity_, original_bounds.at(0)->at(bound_idx).min_velocity_);
+      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).velocity_bounded_,
+                original_bounds.at(0)->at(bound_idx).velocity_bounded_);
 
-//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).max_acceleration_,
-//                 original_bounds.at(0)->at(bound_idx).max_acceleration_);
-//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).min_acceleration_,
-//                 original_bounds.at(0)->at(bound_idx).min_acceleration_);
-//       ASSERT_EQ(test_bounds.at(0)->at(bound_idx).acceleration_bounded_,
-//                 original_bounds.at(0)->at(bound_idx).acceleration_bounded_);
-//     }
-//     ASSERT_EQ(test_trajectory.getWayPointDurationFromPrevious(1), trajectory.getWayPointDurationFromPrevious(1));
+      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).max_acceleration_,
+                original_bounds.at(0)->at(bound_idx).max_acceleration_);
+      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).min_acceleration_,
+                original_bounds.at(0)->at(bound_idx).min_acceleration_);
+      ASSERT_EQ(test_bounds.at(0)->at(bound_idx).acceleration_bounded_,
+                original_bounds.at(0)->at(bound_idx).acceleration_bounded_);
+    }
+    ASSERT_EQ(test_trajectory.getWayPointDurationFromPrevious(1), trajectory.getWayPointDurationFromPrevious(1));
 
-//     TimeOptimalTrajectoryGeneration totg;
-//     ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";
+    TimeOptimalTrajectoryGeneration totg;
+    ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";
 
-//     test_trajectory.getRobotTrajectoryMsg(first_trajectory_msg_start);
+    test_trajectory.getRobotTrajectoryMsg(first_trajectory_msg_start);
 
-//     // Iteratively recompute timestamps with same totg instance
-//     for (size_t i = 0; i < totg_iterations; ++i)
-//     {
-//       bool totg_success = totg.computeTimeStamps(test_trajectory);
-//       EXPECT_TRUE(totg_success) << "Failed to compute time stamps with a same TOTG instance in iteration " << i;
-//     }
+    // Iteratively recompute timestamps with same totg instance
+    for (size_t i = 0; i < totg_iterations; ++i)
+    {
+      bool totg_success = totg.computeTimeStamps(test_trajectory);
+      EXPECT_TRUE(totg_success) << "Failed to compute time stamps with a same TOTG instance in iteration " << i;
+    }
 
-//     test_trajectory.getRobotTrajectoryMsg(first_trajectory_msg_end);
-//   }
+    test_trajectory.getRobotTrajectoryMsg(first_trajectory_msg_end);
+  }
 
-//   // Test computing the dynamics repeatedly with one TOTG instance per call
-//   moveit_msgs::RobotTrajectory second_trajectory_msg_start, second_trajectory_msg_end;
-//   {
-//     robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
+  // Test computing the dynamics repeatedly with one TOTG instance per call
+  moveit_msgs::RobotTrajectory second_trajectory_msg_start, second_trajectory_msg_end;
+  {
+    robot_trajectory::RobotTrajectory test_trajectory(trajectory, true /* deep copy */);
 
-//     {
-//       TimeOptimalTrajectoryGeneration totg;
-//       ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";
-//     }
+    {
+      TimeOptimalTrajectoryGeneration totg;
+      ASSERT_TRUE(totg.computeTimeStamps(test_trajectory)) << "Failed to compute time stamps";
+    }
 
-//     test_trajectory.getRobotTrajectoryMsg(second_trajectory_msg_start);
+    test_trajectory.getRobotTrajectoryMsg(second_trajectory_msg_start);
 
-//     // Iteratively recompute timestamps with new totg instances
-//     for (size_t i = 0; i < totg_iterations; ++i)
-//     {
-//       TimeOptimalTrajectoryGeneration totg;
-//       bool totg_success = totg.computeTimeStamps(test_trajectory);
-//       EXPECT_TRUE(totg_success) << "Failed to compute time stamps with a new TOTG instance in iteration " << i;
-//     }
+    // Iteratively recompute timestamps with new totg instances
+    for (size_t i = 0; i < totg_iterations; ++i)
+    {
+      TimeOptimalTrajectoryGeneration totg;
+      bool totg_success = totg.computeTimeStamps(test_trajectory);
+      EXPECT_TRUE(totg_success) << "Failed to compute time stamps with a new TOTG instance in iteration " << i;
+    }
 
-//     test_trajectory.getRobotTrajectoryMsg(second_trajectory_msg_end);
-//   }
+    test_trajectory.getRobotTrajectoryMsg(second_trajectory_msg_end);
+  }
 
-//   // Make sure trajectories produce equal waypoints independent of TOTG instances
-//   ASSERT_EQ(first_trajectory_msg_start, second_trajectory_msg_start);
-//   ASSERT_EQ(first_trajectory_msg_end, second_trajectory_msg_end);
+  // Make sure trajectories produce equal waypoints independent of TOTG instances
+  ASSERT_EQ(first_trajectory_msg_start, second_trajectory_msg_start);
+  ASSERT_EQ(first_trajectory_msg_end, second_trajectory_msg_end);
 
-//   // Iterate on the original trajectory again
-//   moveit_msgs::RobotTrajectory third_trajectory_msg_end;
+  // Iterate on the original trajectory again
+  moveit_msgs::RobotTrajectory third_trajectory_msg_end;
 
-//   {
-//     TimeOptimalTrajectoryGeneration totg;
-//     ASSERT_TRUE(totg.computeTimeStamps(trajectory)) << "Failed to compute time stamps";
-//   }
+  {
+    TimeOptimalTrajectoryGeneration totg;
+    ASSERT_TRUE(totg.computeTimeStamps(trajectory)) << "Failed to compute time stamps";
+  }
 
-//   for (size_t i = 0; i < totg_iterations; ++i)
-//   {
-//     TimeOptimalTrajectoryGeneration totg;
-//     bool totg_success = totg.computeTimeStamps(trajectory);
-//     ASSERT_TRUE(totg_success) << "Failed to compute timestamps on a new TOTG instance in iteration " << i;
-//   }
+  for (size_t i = 0; i < totg_iterations; ++i)
+  {
+    TimeOptimalTrajectoryGeneration totg;
+    bool totg_success = totg.computeTimeStamps(trajectory);
+    ASSERT_TRUE(totg_success) << "Failed to compute timestamps on a new TOTG instance in iteration " << i;
+  }
 
-//   // Compare with previous work
-//   trajectory.getRobotTrajectoryMsg(third_trajectory_msg_end);
+  // Compare with previous work
+  trajectory.getRobotTrajectoryMsg(third_trajectory_msg_end);
 
-//   // Make sure trajectories produce equal waypoints independent of TOTG instances
-//   ASSERT_EQ(first_trajectory_msg_end, third_trajectory_msg_end);
-// }
+  // Make sure trajectories produce equal waypoints independent of TOTG instances
+  ASSERT_EQ(first_trajectory_msg_end, third_trajectory_msg_end);
+}
 
 TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
 {

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -40,6 +40,10 @@
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <moveit/utils/robot_model_test_utils.h>
 
+#include <iostream>  // std::cout
+#include <sstream>   // std::stringstream
+#include <string>    // std::string
+
 using trajectory_processing::Path;
 using trajectory_processing::TimeOptimalTrajectoryGeneration;
 using trajectory_processing::Trajectory;
@@ -376,6 +380,10 @@ TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
   // Start matches
   EXPECT_DOUBLE_EQ(start_position, trajectory.getPosition(0.0)[0]);
 
+  std::stringstream buffer;
+  // Redirect std::cerr to buffer
+  std::streambuf* cerr_buf = std::cerr.rdbuf(buffer.rdbuf());
+
   // Check vels and accels at all points
   for (double time = 0; time < traj_duration; time += 0.01)
   {
@@ -394,6 +402,8 @@ TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
       EXPECT_NEAR(trajectory.getAcceleration(time)[0], -max_accelerations[0], 1e-3) << "Time: " << time;
     }
   }
+
+  std::cerr.rdbuf(cerr_buf);
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -40,10 +40,6 @@
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 #include <moveit/utils/robot_model_test_utils.h>
 
-#include <iostream>  // std::cout
-#include <sstream>   // std::stringstream
-#include <string>    // std::string
-
 using trajectory_processing::Path;
 using trajectory_processing::TimeOptimalTrajectoryGeneration;
 using trajectory_processing::Trajectory;
@@ -78,6 +74,11 @@ TEST(time_optimal_trajectory_generation, test1)
   EXPECT_DOUBLE_EQ(985.000244140625, trajectory.getPosition(trajectory.getDuration())[1]);
   EXPECT_DOUBLE_EQ(2126.0, trajectory.getPosition(trajectory.getDuration())[2]);
   EXPECT_DOUBLE_EQ(0.0, trajectory.getPosition(trajectory.getDuration())[3]);
+
+  // Start at rest and end at rest
+  const double traj_duration = trajectory.getDuration();
+  EXPECT_NEAR(0.0, trajectory.getVelocity(0.0)[0], 0.1);
+  EXPECT_NEAR(0.0, trajectory.getVelocity(traj_duration)[0], 0.1);
 }
 
 TEST(time_optimal_trajectory_generation, test2)
@@ -116,6 +117,11 @@ TEST(time_optimal_trajectory_generation, test2)
   EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
   EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
+
+  // Start at rest and end at rest
+  const double traj_duration = trajectory.getDuration();
+  EXPECT_NEAR(0.0, trajectory.getVelocity(0.0)[0], 0.1);
+  EXPECT_NEAR(0.0, trajectory.getVelocity(traj_duration)[0], 0.1);
 }
 
 TEST(time_optimal_trajectory_generation, test3)
@@ -154,6 +160,11 @@ TEST(time_optimal_trajectory_generation, test3)
   EXPECT_DOUBLE_EQ(533.0, trajectory.getPosition(trajectory.getDuration())[1]);
   EXPECT_DOUBLE_EQ(951.0, trajectory.getPosition(trajectory.getDuration())[2]);
   EXPECT_DOUBLE_EQ(90.0, trajectory.getPosition(trajectory.getDuration())[3]);
+
+  // Start at rest and end at rest
+  const double traj_duration = trajectory.getDuration();
+  EXPECT_NEAR(0.0, trajectory.getVelocity(0.0)[0], 0.1);
+  EXPECT_NEAR(0.0, trajectory.getVelocity(traj_duration)[0], 0.1);
 }
 
 // Test that totg algorithm doesn't give large acceleration
@@ -379,11 +390,9 @@ TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
 
   // Start matches
   EXPECT_DOUBLE_EQ(start_position, trajectory.getPosition(0.0)[0]);
-
-  std::cerr << "Getting accel at 0.01: " << std::endl;
-  trajectory.getAcceleration(0.01)[0];
-  std::cerr << "Getting accel at 0.02: " << std::endl;
-  trajectory.getAcceleration(0.02)[0];
+  // Start at rest and end at rest
+  EXPECT_NEAR(0.0, trajectory.getVelocity(0.0)[0], 0.1);
+  EXPECT_NEAR(0.0, trajectory.getVelocity(traj_duration)[0], 0.1);
 
   // Check vels and accels at all points
   for (double time = 0; time < traj_duration; time += 0.01)
@@ -399,11 +408,6 @@ TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
       EXPECT_NEAR(trajectory.getAcceleration(time)[0], -max_accelerations[0], 1e-3) << "Time: " << time;
     }
   }
-
-  std::stringstream buffer;
-  // Redirect std::cerr to buffer
-  std::streambuf* cerr_buf = std::cerr.rdbuf(buffer.rdbuf());
-  std::cerr.rdbuf(cerr_buf);
 }
 
 int main(int argc, char** argv)

--- a/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
+++ b/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp
@@ -380,20 +380,17 @@ TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
   // Start matches
   EXPECT_DOUBLE_EQ(start_position, trajectory.getPosition(0.0)[0]);
 
-  std::stringstream buffer;
-  // Redirect std::cerr to buffer
-  std::streambuf* cerr_buf = std::cerr.rdbuf(buffer.rdbuf());
+  std::cerr << "Getting accel at 0.01: " << std::endl;
+  trajectory.getAcceleration(0.01)[0];
+  std::cerr << "Getting accel at 0.02: " << std::endl;
+  trajectory.getAcceleration(0.02)[0];
 
   // Check vels and accels at all points
   for (double time = 0; time < traj_duration; time += 0.01)
   {
     // This trajectory has a single switching point
     double t_switch = 0.1603407;
-    if (time == 0)
-    {
-      EXPECT_NEAR(trajectory.getAcceleration(time)[0], 0, 1e-3) << "Time: " << time;
-    }
-    else if (time > 0 && time < t_switch)
+    if (time < t_switch)
     {
       EXPECT_NEAR(trajectory.getAcceleration(time)[0], max_accelerations[0], 1e-3) << "Time: " << time;
     }
@@ -403,6 +400,9 @@ TEST(time_optimal_trajectory_generation, testSingleDofDiscontinuity)
     }
   }
 
+  std::stringstream buffer;
+  // Redirect std::cerr to buffer
+  std::streambuf* cerr_buf = std::cerr.rdbuf(buffer.rdbuf());
   std::cerr.rdbuf(cerr_buf);
 }
 


### PR DESCRIPTION
This is a 2-line bug fix for this test failure:

```
/home/andy/ws_moveit/src/moveit/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp:395: Failure
The difference between trajectory.getAcceleration(time)[0] and max_accelerations[0] is 4, which exceeds 1e-3, where
trajectory.getAcceleration(time)[0] evaluates to 32,
max_accelerations[0] evaluates to 28, and
1e-3 evaluates to 0.001.
Time: 0.01
/home/andy/ws_moveit/src/moveit/moveit_core/trajectory_processing/test/test_time_optimal_trajectory_generation.cpp:395: Failure
The difference between trajectory.getAcceleration(time)[0] and max_accelerations[0] is 28, which exceeds 1e-3, where
trajectory.getAcceleration(time)[0] evaluates to 0,
max_accelerations[0] evaluates to 28, and
1e-3 evaluates to 0.001.
Time: 0.02
```