### PR TITLE
Add JointModel::satisfiesAccelerationBounds()

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -322,6 +322,15 @@ public:
   /** \brief Force the specified velocities to be inside bounds. Return true if changes were made. */
   virtual bool enforceVelocityBounds(double* values, const Bounds& other_bounds) const;
 
+  /** \brief Check if the set of accelerations for the variables of this joint are within bounds. */
+  bool satisfiesAccelerationBounds(const double* values, double margin = 0.0) const
+  {
+    return satisfiesAccelerationBounds(values, variable_bounds_, margin);
+  }
+
+  /** \brief Check if the set of accelerations for the variables of this joint are within bounds, up to some margin. */
+  virtual bool satisfiesAccelerationBounds(const double* values, const Bounds& other_bounds, double margin) const;
+
   /** \brief Get the bounds for a variable. Throw an exception if the variable was not found */
   const VariableBounds& getVariableBounds(const std::string& variable) const;
 

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -122,6 +122,16 @@ bool JointModel::satisfiesVelocityBounds(const double* values, const Bounds& oth
   return true;
 }
 
+bool JointModel::satisfiesAccelerationBounds(const double* values, const Bounds& other_bounds, double margin) const
+{
+  for (std::size_t i = 0; i < other_bounds.size(); ++i)
+    if (other_bounds[i].max_acceleration_ + margin < values[i])
+      return false;
+    else if (other_bounds[i].min_acceleration_ - margin > values[i])
+      return false;
+  return true;
+}
+
 const VariableBounds& JointModel::getVariableBounds(const std::string& variable) const
 {
   return variable_bounds_[getLocalVariableIndex(variable)];

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -115,20 +115,32 @@ bool JointModel::enforceVelocityBounds(double* values, const Bounds& other_bound
 bool JointModel::satisfiesVelocityBounds(const double* values, const Bounds& other_bounds, double margin) const
 {
   for (std::size_t i = 0; i < other_bounds.size(); ++i)
+  {
+    if (!other_bounds[i].velocity_bounded_)
+    {
+      continue;
+    }
     if (other_bounds[i].max_velocity_ + margin < values[i])
       return false;
     else if (other_bounds[i].min_velocity_ - margin > values[i])
       return false;
+  }
   return true;
 }
 
 bool JointModel::satisfiesAccelerationBounds(const double* values, const Bounds& other_bounds, double margin) const
 {
   for (std::size_t i = 0; i < other_bounds.size(); ++i)
+  {
+    if (!other_bounds[i].acceleration_bounded_)
+    {
+      continue;
+    }
     if (other_bounds[i].max_acceleration_ + margin < values[i])
       return false;
     else if (other_bounds[i].min_acceleration_ - margin > values[i])
       return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
### Description

We already have versions for satisfiesPositionBounds() and satisfiesVelocityBounds(), why not Acceleration too?