### PR TITLE
Address deprecation warnings in Debian bookworm

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_matrix.h
@@ -94,9 +94,6 @@ public:
   /** @brief Construct the structure from a message representation */
   AllowedCollisionMatrix(const moveit_msgs::AllowedCollisionMatrix& msg);
 
-  /** @brief Copy constructor */
-  AllowedCollisionMatrix(const AllowedCollisionMatrix& acm) = default;
-
   /** @brief Get the type of the allowed collision between two elements.
    *  Return true if the entry is included in the collision matrix. Return false if the entry is not found.
    *  @param name1 name of first element

--- a/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
+++ b/moveit_kinematics/cached_ik_kinematics_plugin/include/moveit/cached_ik_kinematics_plugin/detail/NearestNeighborsGNAT.h
@@ -551,7 +551,7 @@ protected:
         std::vector<int> permutation(children_.size());
         for (unsigned int i = 0; i < permutation.size(); ++i)
           permutation[i] = i;
-        std::random_shuffle(permutation.begin(), permutation.end());
+        std::shuffle(permutation.begin(), permutation.end(), std::default_random_engine{});
 
         for (unsigned int i = 0; i < children_.size(); ++i)
           if (permutation[i] >= 0)
@@ -605,7 +605,7 @@ protected:
         std::vector<int> permutation(children_.size());
         for (unsigned int i = 0; i < permutation.size(); ++i)
           permutation[i] = i;
-        std::random_shuffle(permutation.begin(), permutation.end());
+        std::shuffle(permutation.begin(), permutation.end(), std::default_random_engine{});
 
         for (unsigned int i = 0; i < children_.size(); ++i)
           if (permutation[i] >= 0)

--- a/moveit_setup_assistant/src/tools/collision_linear_model.cpp
+++ b/moveit_setup_assistant/src/tools/collision_linear_model.cpp
@@ -273,7 +273,16 @@ bool SortFilterProxyModel::lessThan(const QModelIndex& src_left, const QModelInd
     if (value_left == value_right)
       continue;
 
-    bool smaller = (value_left < value_right);
+    bool smaller{};
+    switch (value_left.type())
+    {
+      case QVariant::Int:
+        smaller = value_left.toInt() < value_right.toInt();
+        break;
+      default:
+        smaller = value_left.toString() < value_right.toString();
+        break;
+    }
     if (sort_orders_[i] == Qt::DescendingOrder)
       smaller = !smaller;
     return smaller;

--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -223,8 +223,8 @@ void SimulationWidget::openURDF()
   QString editor = qgetenv("EDITOR");
   if (editor.isEmpty())
     editor = "xdg-open";
-  auto command = QString("%1 %2").arg(editor, config_data_->urdf_path_.c_str());
-  if (!QProcess::startDetached(command))
+  QStringList args{ QString::fromStdString(config_data_->urdf_path_) };
+  if (!QProcess::startDetached(editor, args))
     QMessageBox::warning(this, "URDF Editor", tr("Failed to open editor: <pre>%1</pre>").arg(editor));
 }
 


### PR DESCRIPTION
- drop implicit CC definition
- avoid deprecated std::random_shuffle
- Fix qt5 deprecation
- do not use deprecated QVariant::operator<

The first four should be rather uncontroversial.

@rhaschke, please have a look at the last one, I expect you don't want to merge this as-is for your generalized code?
