### PR TITLE
MPD: Use different namespaces for RobotInteraction

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1142,8 +1142,11 @@ void MotionPlanningDisplay::onRobotModelLoaded()
   PlanningSceneDisplay::onRobotModelLoaded();
   trajectory_visual_->onRobotModelLoaded(getRobotModel());
 
-  robot_interaction_ =
-      std::make_shared<robot_interaction::RobotInteraction>(getRobotModel(), "rviz_moveit_motion_planning_display");
+  std::string ns = "rviz_moveit_motion_planning_display";
+  std::string robot_desc_ns = ros::names::parentNamespace(robot_description_property_->getStdString());
+  if (!robot_desc_ns.empty())
+    ns = ros::names::append(robot_desc_ns, ns);
+  robot_interaction_ = std::make_shared<robot_interaction::RobotInteraction>(getRobotModel(), ns);
   robot_interaction::KinematicOptions o;
   o.state_validity_callback_ = [this](moveit::core::RobotState* robot_state,
                                       const moveit::core::JointModelGroup* joint_group,


### PR DESCRIPTION
Fixes #3401
All MotionPlanningDisplays use the same fixed namespace for `RobotInteraction`:
https://github.com/ros-planning/moveit/blob/6c5203338bf305e1a9303839ded3afebee423c78/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp#L1146

This causes ambiguities when resolving interactive markers for the same robot model.
My proposal is to prepend the (typically empty) parent namespace of the `robot_description` parameter.
In this fashion, most existing code accessing the interactive marker topics too, will continue to work.