### PR TITLE
Read goal tolerances from kinematics configuration

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -73,6 +73,21 @@ MOVEIT_CLASS_FORWARD(MoveGroupInterface);  // Defines MoveGroupInterfacePtr, Con
 class MoveGroupInterface
 {
 public:
+  /** \brief Default goal joint tolerance (0.1mm) if not specified with {robot description name}_kinematics/{joint model group name}/goal_joint_tolerance */
+  static constexpr double DEFAULT_GOAL_JOINT_TOLERANCE = 1e-4;
+
+  /** \brief Default goal position tolerance (0.1mm) if not specified with {robot description name}_kinematics/{joint model group name}/goal_position_tolerance */
+  static constexpr double DEFAULT_GOAL_POSITION_TOLERANCE = 1e-4;
+
+  /** \brief Default goal orientation tolerance (~0.1deg) if not specified with {robot description name}_kinematics/{joint model group name}/goal_orientation_tolerance */
+  static constexpr double DEFAULT_GOAL_ORIENTATION_TOLERANCE = 1e-3;
+
+  /** \brief Default allowed planning time (seconds) */
+  static constexpr double DEFAULT_ALLOWED_PLANNING_TIME = 5.0;
+
+  /** \brief Default number of planning attempts */
+  static constexpr int DEFAULT_NUM_PLANNING_ATTEMPTS = 1;
+
   /** \brief Default ROS parameter name from where to read the robot's URDF. Set to 'robot_description' */
   static const std::string ROBOT_DESCRIPTION;
 

--- a/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
+++ b/moveit_ros/planning_interface/move_group_interface/include/moveit/move_group_interface/move_group_interface.h
@@ -73,13 +73,16 @@ MOVEIT_CLASS_FORWARD(MoveGroupInterface);  // Defines MoveGroupInterfacePtr, Con
 class MoveGroupInterface
 {
 public:
-  /** \brief Default goal joint tolerance (0.1mm) if not specified with {robot description name}_kinematics/{joint model group name}/goal_joint_tolerance */
+  /** \brief Default goal joint tolerance (0.1mm) if not specified with {robot description name}_kinematics/{joint model
+   * group name}/goal_joint_tolerance */
   static constexpr double DEFAULT_GOAL_JOINT_TOLERANCE = 1e-4;
 
-  /** \brief Default goal position tolerance (0.1mm) if not specified with {robot description name}_kinematics/{joint model group name}/goal_position_tolerance */
+  /** \brief Default goal position tolerance (0.1mm) if not specified with {robot description name}_kinematics/{joint
+   * model group name}/goal_position_tolerance */
   static constexpr double DEFAULT_GOAL_POSITION_TOLERANCE = 1e-4;
 
-  /** \brief Default goal orientation tolerance (~0.1deg) if not specified with {robot description name}_kinematics/{joint model group name}/goal_orientation_tolerance */
+  /** \brief Default goal orientation tolerance (~0.1deg) if not specified with {robot description
+   * name}_kinematics/{joint model group name}/goal_orientation_tolerance */
   static constexpr double DEFAULT_GOAL_ORIENTATION_TOLERANCE = 1e-3;
 
   /** \brief Default allowed planning time (seconds) */

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -125,15 +125,29 @@ public:
     can_replan_ = false;
     replan_delay_ = 2.0;
     replan_attempts_ = 1;
-    goal_joint_tolerance_ = 1e-4;
-    goal_position_tolerance_ = 1e-4;     // 0.1 mm
-    goal_orientation_tolerance_ = 1e-3;  // ~0.1 deg
-    allowed_planning_time_ = 5.0;
-    num_planning_attempts_ = 1;
+    allowed_planning_time_ = DEFAULT_ALLOWED_PLANNING_TIME;
+    num_planning_attempts_ = DEFAULT_NUM_PLANNING_ATTEMPTS;
     max_cartesian_speed_ = 0.0;
-    node_handle_.param<double>("robot_description_planning/default_velocity_scaling_factor",
+
+    std::string desc = opt.robot_description_.length()
+      ? opt.robot_description_
+      : ROBOT_DESCRIPTION;
+
+    std::string kinematics_desc = desc + "_kinematics/";
+    node_handle_.param<double>(kinematics_desc + opt.group_name_ + "/goal_joint_tolerance",
+                               goal_joint_tolerance_,
+                               DEFAULT_GOAL_JOINT_TOLERANCE);
+    node_handle_.param<double>(kinematics_desc + opt.group_name_ + "/goal_position_tolerance",
+                               goal_position_tolerance_,
+                               DEFAULT_GOAL_POSITION_TOLERANCE);
+    node_handle_.param<double>(kinematics_desc + opt.group_name_ + "/goal_orientation_tolerance",
+                               goal_orientation_tolerance_,
+                               DEFAULT_GOAL_ORIENTATION_TOLERANCE);
+
+    std::string planning_desc = desc + "_planning/";
+    node_handle_.param<double>(planning_desc + "default_velocity_scaling_factor",
                                max_velocity_scaling_factor_, 0.1);
-    node_handle_.param<double>("robot_description_planning/default_acceleration_scaling_factor",
+    node_handle_.param<double>(planning_desc + "default_acceleration_scaling_factor",
                                max_acceleration_scaling_factor_, 0.1);
     initializing_constraints_ = false;
 

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -129,26 +129,20 @@ public:
     num_planning_attempts_ = DEFAULT_NUM_PLANNING_ATTEMPTS;
     max_cartesian_speed_ = 0.0;
 
-    std::string desc = opt.robot_description_.length()
-      ? opt.robot_description_
-      : ROBOT_DESCRIPTION;
+    std::string desc = opt.robot_description_.length() ? opt.robot_description_ : ROBOT_DESCRIPTION;
 
     std::string kinematics_desc = desc + "_kinematics/";
-    node_handle_.param<double>(kinematics_desc + opt.group_name_ + "/goal_joint_tolerance",
-                               goal_joint_tolerance_,
+    node_handle_.param<double>(kinematics_desc + opt.group_name_ + "/goal_joint_tolerance", goal_joint_tolerance_,
                                DEFAULT_GOAL_JOINT_TOLERANCE);
-    node_handle_.param<double>(kinematics_desc + opt.group_name_ + "/goal_position_tolerance",
-                               goal_position_tolerance_,
+    node_handle_.param<double>(kinematics_desc + opt.group_name_ + "/goal_position_tolerance", goal_position_tolerance_,
                                DEFAULT_GOAL_POSITION_TOLERANCE);
     node_handle_.param<double>(kinematics_desc + opt.group_name_ + "/goal_orientation_tolerance",
-                               goal_orientation_tolerance_,
-                               DEFAULT_GOAL_ORIENTATION_TOLERANCE);
+                               goal_orientation_tolerance_, DEFAULT_GOAL_ORIENTATION_TOLERANCE);
 
     std::string planning_desc = desc + "_planning/";
-    node_handle_.param<double>(planning_desc + "default_velocity_scaling_factor",
-                               max_velocity_scaling_factor_, 0.1);
-    node_handle_.param<double>(planning_desc + "default_acceleration_scaling_factor",
-                               max_acceleration_scaling_factor_, 0.1);
+    node_handle_.param<double>(planning_desc + "default_velocity_scaling_factor", max_velocity_scaling_factor_, 0.1);
+    node_handle_.param<double>(planning_desc + "default_acceleration_scaling_factor", max_acceleration_scaling_factor_,
+                               0.1);
     initializing_constraints_ = false;
 
     if (joint_model_group_->isChain())

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -57,6 +57,9 @@ static const std::string MOVEIT_ROBOT_STATE = "moveit_robot_state";
 // Default kin solver values
 static const double DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION = 0.005;
 static const double DEFAULT_KIN_SOLVER_TIMEOUT = 0.005;
+static const double DEFAULT_GOAL_JOINT_TOLERANCE = 1e-4;
+static const double DEFAULT_GOAL_POSITION_TOLERANCE = 1e-4;
+static const double DEFAULT_GOAL_ORIENTATION_TOLERANCE = 1e-3;
 
 // ******************************************************************************************
 // Structs

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -57,9 +57,6 @@ static const std::string MOVEIT_ROBOT_STATE = "moveit_robot_state";
 // Default kin solver values
 static const double DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION = 0.005;
 static const double DEFAULT_KIN_SOLVER_TIMEOUT = 0.005;
-static const double DEFAULT_GOAL_JOINT_TOLERANCE = 1e-4;
-static const double DEFAULT_GOAL_POSITION_TOLERANCE = 1e-4;
-static const double DEFAULT_GOAL_ORIENTATION_TOLERANCE = 1e-3;
 
 // ******************************************************************************************
 // Structs

--- a/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
+++ b/moveit_setup_assistant/include/moveit/setup_assistant/tools/moveit_config_data.h
@@ -73,6 +73,9 @@ struct GroupMetaData
   std::string kinematics_solver_;               // Name of kinematics plugin to use
   double kinematics_solver_search_resolution_;  // resolution to use with solver
   double kinematics_solver_timeout_;            // solver timeout
+  double goal_joint_tolerance_;                 // joint tolerance for goal constraints
+  double goal_position_tolerance_;              // position tolerance for goal constraints
+  double goal_orientation_tolerance_;           // orientation tolerance for goal constraints
   std::string kinematics_parameters_file_;      // file for additional kinematics parameters
   std::string default_planner_;                 // Name of the default planner to use
 };

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -35,6 +35,7 @@
 /* Author: Dave Coleman */
 
 #include <moveit/setup_assistant/tools/moveit_config_data.h>
+#include <moveit/move_group_interface/move_group_interface.h>
 
 // Reading/Writing Files
 #include <iostream>  // For writing yaml and launch files

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -481,6 +481,18 @@ bool MoveItConfigData::outputKinematicsYAML(const std::string& file_path)
     emitter << YAML::Key << "kinematics_solver_timeout";
     emitter << YAML::Value << group_meta_data_[group.name_].kinematics_solver_timeout_;
 
+    // Goal joint tolerance
+    emitter << YAML::Key << "goal_joint_tolerance";
+    emitter << YAML::Value << DEFAULT_GOAL_JOINT_TOLERANCE;
+
+    // Goal position tolerance
+    emitter << YAML::Key << "goal_position_tolerance";
+    emitter << YAML::Value << DEFAULT_GOAL_POSITION_TOLERANCE;
+
+    // Goal orientation tolerance
+    emitter << YAML::Key << "goal_orientation_tolerance";
+    emitter << YAML::Value << DEFAULT_GOAL_ORIENTATION_TOLERANCE;
+
     emitter << YAML::EndMap;
   }
 

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1350,10 +1350,12 @@ bool MoveItConfigData::inputKinematicsYAML(const std::string& file_path)
       parse(group, "kinematics_solver_search_resolution", meta_data.kinematics_solver_search_resolution_,
             DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION);
       parse(group, "kinematics_solver_timeout", meta_data.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT);
-      parse(group, "goal_joint_tolerance", meta_data.goal_joint_tolerance_, DEFAULT_GOAL_JOINT_TOLERANCE);
-      parse(group, "goal_position_tolerance", meta_data.goal_position_tolerance_, DEFAULT_GOAL_POSITION_TOLERANCE);
+      parse(group, "goal_joint_tolerance", meta_data.goal_joint_tolerance_,
+            moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_JOINT_TOLERANCE);
+      parse(group, "goal_position_tolerance", meta_data.goal_position_tolerance_,
+            moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_POSITION_TOLERANCE);
       parse(group, "goal_orientation_tolerance", meta_data.goal_orientation_tolerance_,
-            DEFAULT_GOAL_ORIENTATION_TOLERANCE);
+            moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_ORIENTATION_TOLERANCE);
 
       // Assign meta data to vector
       group_meta_data_[group_name] = std::move(meta_data);

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -483,15 +483,15 @@ bool MoveItConfigData::outputKinematicsYAML(const std::string& file_path)
 
     // Goal joint tolerance
     emitter << YAML::Key << "goal_joint_tolerance";
-    emitter << YAML::Value << DEFAULT_GOAL_JOINT_TOLERANCE;
+    emitter << YAML::Value << group_meta_data_[group.name_].goal_joint_tolerance_;
 
     // Goal position tolerance
     emitter << YAML::Key << "goal_position_tolerance";
-    emitter << YAML::Value << DEFAULT_GOAL_POSITION_TOLERANCE;
+    emitter << YAML::Value << group_meta_data_[group.name_].goal_position_tolerance_;
 
     // Goal orientation tolerance
     emitter << YAML::Key << "goal_orientation_tolerance";
-    emitter << YAML::Value << DEFAULT_GOAL_ORIENTATION_TOLERANCE;
+    emitter << YAML::Value << group_meta_data_[group.name_].goal_orientation_tolerance_;
 
     emitter << YAML::EndMap;
   }
@@ -1349,6 +1349,10 @@ bool MoveItConfigData::inputKinematicsYAML(const std::string& file_path)
       parse(group, "kinematics_solver_search_resolution", meta_data.kinematics_solver_search_resolution_,
             DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION);
       parse(group, "kinematics_solver_timeout", meta_data.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT);
+      parse(group, "goal_joint_tolerance", meta_data.goal_joint_tolerance_, DEFAULT_GOAL_JOINT_TOLERANCE);
+      parse(group, "goal_position_tolerance", meta_data.goal_position_tolerance_, DEFAULT_GOAL_POSITION_TOLERANCE);
+      parse(group, "goal_orientation_tolerance", meta_data.goal_orientation_tolerance_,
+            DEFAULT_GOAL_ORIENTATION_TOLERANCE);
 
       // Assign meta data to vector
       group_meta_data_[group_name] = std::move(meta_data);

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -281,14 +281,18 @@ void GroupEditWidget::setSelected(const std::string& group_name)
   setLineEditValue(group_metadata.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT, kinematics_timeout_field_);
 
   // Load goal joint tolerance
-  setSpinBoxValue(group_metadata.goal_joint_tolerance_, DEFAULT_GOAL_JOINT_TOLERANCE, goal_joint_tolerance_field_);
+  setSpinBoxValue(group_metadata.goal_joint_tolerance_,
+                  moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_JOINT_TOLERANCE,
+                  goal_joint_tolerance_field_);
 
   // Load goal position tolerance
-  setSpinBoxValue(group_metadata.goal_position_tolerance_, DEFAULT_GOAL_POSITION_TOLERANCE,
+  setSpinBoxValue(group_metadata.goal_position_tolerance_,
+                  moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_POSITION_TOLERANCE,
                   goal_position_tolerance_field_);
 
   // Load goal orientation tolerance
-  setSpinBoxValue(group_metadata.goal_orientation_tolerance_, DEFAULT_GOAL_ORIENTATION_TOLERANCE,
+  setSpinBoxValue(group_metadata.goal_orientation_tolerance_,
+                  moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_ORIENTATION_TOLERANCE,
                   goal_orientation_tolerance_field_);
 
   // Set kin solver

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -41,6 +41,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QDoubleSpinBox>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QString>
@@ -52,11 +53,36 @@
 namespace moveit_setup_assistant
 {
 // ******************************************************************************************
-//
+// Constructor
 // ******************************************************************************************
 GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& config_data)
   : QWidget(parent), config_data_(config_data)
 {
+  auto addLineEdit = [this](QFormLayout* form, const QString& label) {
+    QLineEdit* field = new QLineEdit(this);
+    field->setMaximumWidth(FORM_CONTROL_WIDTH);
+    form->addRow(label, field);
+    return field;
+  };
+
+  auto addSpinBox = [this](QFormLayout* form, const QString& label, double min, double max, double step, int decimals) {
+    QDoubleSpinBox* field = new QDoubleSpinBox(this);
+    field->setMaximumWidth(FORM_CONTROL_WIDTH);
+    field->setRange(min, max);
+    field->setDecimals(decimals);
+    field->setSingleStep(step);
+    form->addRow(label, field);
+    return field;
+  };
+
+  auto addComboBox = [this](QFormLayout* form, const QString& label, bool editable = false) {
+    QComboBox* field = new QComboBox(this);
+    field->setEditable(editable);
+    field->setMaximumWidth(FORM_CONTROL_WIDTH);
+    form->addRow(label, field);
+    return field;
+  };
+
   // Basic widget container
   QVBoxLayout* layout = new QVBoxLayout();
 
@@ -74,44 +100,32 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& con
   form_layout->setContentsMargins(0, 12, 0, 12);
 
   // Name input
-  group_name_field_ = new QLineEdit(this);
-  group_name_field_->setMaximumWidth(400);
-  form_layout->addRow("Group Name:", group_name_field_);
+  group_name_field_ = addLineEdit(form_layout, "Group Name:");
 
-  // Kinematic solver
-  kinematics_solver_field_ = new QComboBox(this);
-  kinematics_solver_field_->setEditable(false);
-  kinematics_solver_field_->setMaximumWidth(400);
-  form_layout->addRow("Kinematic Solver:", kinematics_solver_field_);
+  // Kinematic solver to use
+  kinematics_solver_field_ = addComboBox(form_layout, "Kinematic Solver:");
 
-  // resolution to use with solver
-  kinematics_resolution_field_ = new QLineEdit(this);
-  kinematics_resolution_field_->setMaximumWidth(400);
-  form_layout->addRow("Kin. Search Resolution:", kinematics_resolution_field_);
+  // Resolution to use with solver
+  kinematics_resolution_field_ = addLineEdit(form_layout, "Kin. Search Resolution:");
 
-  // resolution to use with solver
-  kinematics_timeout_field_ = new QLineEdit(this);
-  kinematics_timeout_field_->setMaximumWidth(400);
-  form_layout->addRow("Kin. Search Timeout (sec):", kinematics_timeout_field_);
+  // Timeout to use with solver
+  kinematics_timeout_field_ = addLineEdit(form_layout, "Kin. Search Timeout (sec):");
 
   // goal joint tolerance to use when planning with solver
-  goal_joint_tolerance_field_ = new QLineEdit(this);
-  goal_joint_tolerance_field_->setMaximumWidth(400);
-  form_layout->addRow("Goal Joint Tolerance (m):", goal_joint_tolerance_field_);
+  goal_joint_tolerance_field_ = addSpinBox(form_layout, "Goal Joint Tolerance (m|rad):", MIN_TOLERANCE, MAX_TOLERANCE,
+                                           STEP_TOLERANCE, DECIMALS_TOLERANCE);
 
   // goal position tolerance to use when planning with solver
-  goal_position_tolerance_field_ = new QLineEdit(this);
-  goal_position_tolerance_field_->setMaximumWidth(400);
-  form_layout->addRow("Goal Position Tolerance (m):", goal_position_tolerance_field_);
+  goal_position_tolerance_field_ = addSpinBox(form_layout, "Goal Position Tolerance (m):", MIN_TOLERANCE, MAX_TOLERANCE,
+                                              STEP_TOLERANCE, DECIMALS_TOLERANCE);
 
   // goal orientation tolerance to use when planning with solver
-  goal_orientation_tolerance_field_ = new QLineEdit(this);
-  goal_orientation_tolerance_field_->setMaximumWidth(400);
-  form_layout->addRow("Goal Orientation Tolerance (rad):", goal_orientation_tolerance_field_);
+  goal_orientation_tolerance_field_ = addSpinBox(form_layout, "Goal Orientation Tolerance (rad):", MIN_TOLERANCE,
+                                                 MAX_TOLERANCE, STEP_TOLERANCE, DECIMALS_TOLERANCE);
 
   // file to load additional parameters from
   kinematics_parameters_file_field_ = new QLineEdit(this);
-  kinematics_parameters_file_field_->setMaximumWidth(400);
+  kinematics_parameters_file_field_->setMaximumWidth(FORM_CONTROL_WIDTH);
   QPushButton* kinematics_parameters_file_button = new QPushButton("...", this);
   kinematics_parameters_file_button->setMaximumWidth(50);
   connect(kinematics_parameters_file_button, SIGNAL(clicked()), this, SLOT(selectKinematicsFile()));
@@ -131,10 +145,7 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& con
   form_layout2->setContentsMargins(0, 12, 0, 12);
 
   // Kinematic default planner
-  default_planner_field_ = new QComboBox(this);
-  default_planner_field_->setEditable(false);
-  default_planner_field_->setMaximumWidth(400);
-  form_layout2->addRow("Group Default Planner:", default_planner_field_);
+  default_planner_field_ = addComboBox(form_layout2, "Group Default Planner:");
 
   group2->setLayout(form_layout2);
 
@@ -245,54 +256,42 @@ void GroupEditWidget::setSelected(const std::string& group_name)
   group_name_field_->setText(QString(group_name.c_str()));
 
   // Load properties from moveit_config_data.cpp ----------------------------------------------
+  auto setSpinBoxValue = [](double& value, const double defaultValue, QDoubleSpinBox* widget) {
+    if (value <= 0)
+      value = defaultValue;
+
+    widget->setValue(value);
+  };
+
+  auto setLineEditValue = [](double& value, const double defaultValue, QLineEdit* widget) {
+    if (value <= 0)
+      value = defaultValue;
+
+    widget->setText(QString::number(value));
+  };
+
+  GroupMetaData& group_metadata = config_data_->group_meta_data_[group_name];
 
   // Load resolution
-  double* resolution = &config_data_->group_meta_data_[group_name].kinematics_solver_search_resolution_;
-  if (*resolution == 0)
-  {
-    // Set default value
-    *resolution = DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION;
-  }
-  kinematics_resolution_field_->setText(QString::number(*resolution));
+  setLineEditValue(group_metadata.kinematics_solver_search_resolution_, DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION,
+                   kinematics_resolution_field_);
 
   // Load timeout
-  double* timeout = &config_data_->group_meta_data_[group_name].kinematics_solver_timeout_;
-  if (*timeout == 0)
-  {
-    // Set default value
-    *timeout = DEFAULT_KIN_SOLVER_TIMEOUT;
-  }
-  kinematics_timeout_field_->setText(QString::number(*timeout));
+  setLineEditValue(group_metadata.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT, kinematics_timeout_field_);
 
   // Load goal joint tolerance
-  double* goal_joint_tolerance = &config_data_->group_meta_data_[group_name].goal_joint_tolerance_;
-  if (*goal_joint_tolerance == 0)
-  {
-    // Set default value
-    *goal_joint_tolerance = DEFAULT_GOAL_JOINT_TOLERANCE;
-  }
-  goal_joint_tolerance_field_->setText(QString::number(*goal_joint_tolerance));
+  setSpinBoxValue(group_metadata.goal_joint_tolerance_, DEFAULT_GOAL_JOINT_TOLERANCE, goal_joint_tolerance_field_);
 
   // Load goal position tolerance
-  double* goal_position_tolerance = &config_data_->group_meta_data_[group_name].goal_position_tolerance_;
-  if (*goal_position_tolerance == 0)
-  {
-    // Set default value
-    *goal_position_tolerance = DEFAULT_GOAL_POSITION_TOLERANCE;
-  }
-  goal_position_tolerance_field_->setText(QString::number(*goal_position_tolerance));
+  setSpinBoxValue(group_metadata.goal_position_tolerance_, DEFAULT_GOAL_POSITION_TOLERANCE,
+                  goal_position_tolerance_field_);
 
   // Load goal orientation tolerance
-  double* goal_orientation_tolerance = &config_data_->group_meta_data_[group_name].goal_orientation_tolerance_;
-  if (*goal_orientation_tolerance == 0)
-  {
-    // Set default value
-    *goal_orientation_tolerance = DEFAULT_GOAL_ORIENTATION_TOLERANCE;
-  }
-  goal_orientation_tolerance_field_->setText(QString::number(*goal_orientation_tolerance));
+  setSpinBoxValue(group_metadata.goal_orientation_tolerance_, DEFAULT_GOAL_ORIENTATION_TOLERANCE,
+                  goal_orientation_tolerance_field_);
 
   // Set kin solver
-  std::string kin_solver = config_data_->group_meta_data_[group_name].kinematics_solver_;
+  std::string kin_solver = group_metadata.kinematics_solver_;
 
   // If this group doesn't have a solver, reset it to 'None'
   if (kin_solver.empty())
@@ -316,11 +315,10 @@ void GroupEditWidget::setSelected(const std::string& group_name)
     kinematics_solver_field_->setCurrentIndex(index);
   }
 
-  kinematics_parameters_file_field_->setText(
-      config_data_->group_meta_data_[group_name].kinematics_parameters_file_.c_str());
+  kinematics_parameters_file_field_->setText(group_metadata.kinematics_parameters_file_.c_str());
 
   // Set default planner
-  std::string default_planner = config_data_->group_meta_data_[group_name].default_planner_;
+  std::string default_planner = group_metadata.default_planner_;
 
   // If this group doesn't have a solver, reset it to 'None'
   if (default_planner.empty())

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -127,15 +127,16 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& con
 
   // file to load additional parameters from
   kinematics_parameters_file_field_ = new QLineEdit(this);
-  kinematics_parameters_file_field_->setMaximumWidth(FORM_CONTROL_WIDTH);
   QPushButton* kinematics_parameters_file_button = new QPushButton("...", this);
   kinematics_parameters_file_button->setMaximumWidth(50);
+  kinematics_parameters_file_button->setMaximumHeight(42);
   connect(kinematics_parameters_file_button, SIGNAL(clicked()), this, SLOT(selectKinematicsFile()));
   QBoxLayout* kinematics_parameters_file_layout = new QHBoxLayout(this);
   kinematics_parameters_file_layout->addWidget(kinematics_parameters_file_field_);
   kinematics_parameters_file_layout->addWidget(kinematics_parameters_file_button);
   kinematics_parameters_file_layout->setContentsMargins(0, 0, 0, 0);
   QWidget* container = new QWidget(this);
+  container->setMaximumWidth(FORM_CONTROL_WIDTH);
   container->setLayout(kinematics_parameters_file_layout);
   form_layout->addRow("Kin. parameters file:", container);
 

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -59,14 +59,15 @@ namespace moveit_setup_assistant
 GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& config_data)
   : QWidget(parent), config_data_(config_data)
 {
-  auto addLineEdit = [this](QFormLayout* form, const QString& label) {
+  auto add_line_edit = [this](QFormLayout* form, const QString& label) {
     QLineEdit* field = new QLineEdit(this);
     field->setMaximumWidth(FORM_CONTROL_WIDTH);
     form->addRow(label, field);
     return field;
   };
 
-  auto addSpinBox = [this](QFormLayout* form, const QString& label, double min, double max, double step, int decimals) {
+  auto add_spin_box = [this](QFormLayout* form, const QString& label, double min, double max, double step,
+                             int decimals) {
     QDoubleSpinBox* field = new QDoubleSpinBox(this);
     field->setMaximumWidth(FORM_CONTROL_WIDTH);
     field->setRange(min, max);
@@ -76,7 +77,7 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& con
     return field;
   };
 
-  auto addComboBox = [this](QFormLayout* form, const QString& label, bool editable = false) {
+  auto add_combo_box = [this](QFormLayout* form, const QString& label, bool editable = false) {
     QComboBox* field = new QComboBox(this);
     field->setEditable(editable);
     field->setMaximumWidth(FORM_CONTROL_WIDTH);
@@ -101,28 +102,28 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& con
   form_layout->setContentsMargins(0, 12, 0, 12);
 
   // Name input
-  group_name_field_ = addLineEdit(form_layout, "Group Name:");
+  group_name_field_ = add_line_edit(form_layout, "Group Name:");
 
   // Kinematic solver to use
-  kinematics_solver_field_ = addComboBox(form_layout, "Kinematic Solver:");
+  kinematics_solver_field_ = add_combo_box(form_layout, "Kinematic Solver:");
 
   // Resolution to use with solver
-  kinematics_resolution_field_ = addLineEdit(form_layout, "Kin. Search Resolution:");
+  kinematics_resolution_field_ = add_line_edit(form_layout, "Kin. Search Resolution:");
 
   // Timeout to use with solver
-  kinematics_timeout_field_ = addLineEdit(form_layout, "Kin. Search Timeout (sec):");
+  kinematics_timeout_field_ = add_line_edit(form_layout, "Kin. Search Timeout (sec):");
 
   // goal joint tolerance to use when planning with solver
-  goal_joint_tolerance_field_ = addSpinBox(form_layout, "Goal Joint Tolerance (m|rad):", MIN_TOLERANCE, MAX_TOLERANCE,
-                                           STEP_TOLERANCE, DECIMALS_TOLERANCE);
+  goal_joint_tolerance_field_ = add_spin_box(form_layout, "Goal Joint Tolerance (m|rad):", MIN_TOLERANCE, MAX_TOLERANCE,
+                                             STEP_TOLERANCE, DECIMALS_TOLERANCE);
 
   // goal position tolerance to use when planning with solver
-  goal_position_tolerance_field_ = addSpinBox(form_layout, "Goal Position Tolerance (m):", MIN_TOLERANCE, MAX_TOLERANCE,
-                                              STEP_TOLERANCE, DECIMALS_TOLERANCE);
+  goal_position_tolerance_field_ = add_spin_box(form_layout, "Goal Position Tolerance (m):", MIN_TOLERANCE,
+                                                MAX_TOLERANCE, STEP_TOLERANCE, DECIMALS_TOLERANCE);
 
   // goal orientation tolerance to use when planning with solver
-  goal_orientation_tolerance_field_ = addSpinBox(form_layout, "Goal Orientation Tolerance (rad):", MIN_TOLERANCE,
-                                                 MAX_TOLERANCE, STEP_TOLERANCE, DECIMALS_TOLERANCE);
+  goal_orientation_tolerance_field_ = add_spin_box(form_layout, "Goal Orientation Tolerance (rad):", MIN_TOLERANCE,
+                                                   MAX_TOLERANCE, STEP_TOLERANCE, DECIMALS_TOLERANCE);
 
   // file to load additional parameters from
   kinematics_parameters_file_field_ = new QLineEdit(this);
@@ -146,7 +147,7 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& con
   form_layout2->setContentsMargins(0, 12, 0, 12);
 
   // Kinematic default planner
-  default_planner_field_ = addComboBox(form_layout2, "Group Default Planner:");
+  default_planner_field_ = add_combo_box(form_layout2, "Group Default Planner:");
 
   group2->setLayout(form_layout2);
 
@@ -257,14 +258,14 @@ void GroupEditWidget::setSelected(const std::string& group_name)
   group_name_field_->setText(QString(group_name.c_str()));
 
   // Load properties from moveit_config_data.cpp ----------------------------------------------
-  auto setSpinBoxValue = [](double& value, const double defaultValue, QDoubleSpinBox* widget) {
+  auto set_spin_box_value = [](double& value, const double defaultValue, QDoubleSpinBox* widget) {
     if (value <= 0)
       value = defaultValue;
 
     widget->setValue(value);
   };
 
-  auto setLineEditValue = [](double& value, const double defaultValue, QLineEdit* widget) {
+  auto set_line_edit_value = [](double& value, const double defaultValue, QLineEdit* widget) {
     if (value <= 0)
       value = defaultValue;
 
@@ -274,26 +275,26 @@ void GroupEditWidget::setSelected(const std::string& group_name)
   GroupMetaData& group_metadata = config_data_->group_meta_data_[group_name];
 
   // Load resolution
-  setLineEditValue(group_metadata.kinematics_solver_search_resolution_, DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION,
-                   kinematics_resolution_field_);
+  set_line_edit_value(group_metadata.kinematics_solver_search_resolution_, DEFAULT_KIN_SOLVER_SEARCH_RESOLUTION,
+                      kinematics_resolution_field_);
 
   // Load timeout
-  setLineEditValue(group_metadata.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT, kinematics_timeout_field_);
+  set_line_edit_value(group_metadata.kinematics_solver_timeout_, DEFAULT_KIN_SOLVER_TIMEOUT, kinematics_timeout_field_);
 
   // Load goal joint tolerance
-  setSpinBoxValue(group_metadata.goal_joint_tolerance_,
-                  moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_JOINT_TOLERANCE,
-                  goal_joint_tolerance_field_);
+  set_spin_box_value(group_metadata.goal_joint_tolerance_,
+                     moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_JOINT_TOLERANCE,
+                     goal_joint_tolerance_field_);
 
   // Load goal position tolerance
-  setSpinBoxValue(group_metadata.goal_position_tolerance_,
-                  moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_POSITION_TOLERANCE,
-                  goal_position_tolerance_field_);
+  set_spin_box_value(group_metadata.goal_position_tolerance_,
+                     moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_POSITION_TOLERANCE,
+                     goal_position_tolerance_field_);
 
   // Load goal orientation tolerance
-  setSpinBoxValue(group_metadata.goal_orientation_tolerance_,
-                  moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_ORIENTATION_TOLERANCE,
-                  goal_orientation_tolerance_field_);
+  set_spin_box_value(group_metadata.goal_orientation_tolerance_,
+                     moveit::planning_interface::MoveGroupInterface::DEFAULT_GOAL_ORIENTATION_TOLERANCE,
+                     goal_orientation_tolerance_field_);
 
   // Set kin solver
   std::string kin_solver = group_metadata.kinematics_solver_;

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -94,6 +94,21 @@ GroupEditWidget::GroupEditWidget(QWidget* parent, const MoveItConfigDataPtr& con
   kinematics_timeout_field_->setMaximumWidth(400);
   form_layout->addRow("Kin. Search Timeout (sec):", kinematics_timeout_field_);
 
+  // goal joint tolerance to use when planning with solver
+  goal_joint_tolerance_field_ = new QLineEdit(this);
+  goal_joint_tolerance_field_->setMaximumWidth(400);
+  form_layout->addRow("Goal Joint Tolerance (m):", goal_joint_tolerance_field_);
+
+  // goal position tolerance to use when planning with solver
+  goal_position_tolerance_field_ = new QLineEdit(this);
+  goal_position_tolerance_field_->setMaximumWidth(400);
+  form_layout->addRow("Goal Position Tolerance (m):", goal_position_tolerance_field_);
+
+  // goal orientation tolerance to use when planning with solver
+  goal_orientation_tolerance_field_ = new QLineEdit(this);
+  goal_orientation_tolerance_field_->setMaximumWidth(400);
+  form_layout->addRow("Goal Orientation Tolerance (rad):", goal_orientation_tolerance_field_);
+
   // file to load additional parameters from
   kinematics_parameters_file_field_ = new QLineEdit(this);
   kinematics_parameters_file_field_->setMaximumWidth(400);
@@ -248,6 +263,33 @@ void GroupEditWidget::setSelected(const std::string& group_name)
     *timeout = DEFAULT_KIN_SOLVER_TIMEOUT;
   }
   kinematics_timeout_field_->setText(QString::number(*timeout));
+
+  // Load goal joint tolerance
+  double* goal_joint_tolerance = &config_data_->group_meta_data_[group_name].goal_joint_tolerance_;
+  if (*goal_joint_tolerance == 0)
+  {
+    // Set default value
+    *goal_joint_tolerance = DEFAULT_GOAL_JOINT_TOLERANCE;
+  }
+  goal_joint_tolerance_field_->setText(QString::number(*goal_joint_tolerance));
+
+  // Load goal position tolerance
+  double* goal_position_tolerance = &config_data_->group_meta_data_[group_name].goal_position_tolerance_;
+  if (*goal_position_tolerance == 0)
+  {
+    // Set default value
+    *goal_position_tolerance = DEFAULT_GOAL_POSITION_TOLERANCE;
+  }
+  goal_position_tolerance_field_->setText(QString::number(*goal_position_tolerance));
+
+  // Load goal orientation tolerance
+  double* goal_orientation_tolerance = &config_data_->group_meta_data_[group_name].goal_orientation_tolerance_;
+  if (*goal_orientation_tolerance == 0)
+  {
+    // Set default value
+    *goal_orientation_tolerance = DEFAULT_GOAL_ORIENTATION_TOLERANCE;
+  }
+  goal_orientation_tolerance_field_->setText(QString::number(*goal_orientation_tolerance));
 
   // Set kin solver
   std::string kin_solver = config_data_->group_meta_data_[group_name].kinematics_solver_;

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.cpp
@@ -48,6 +48,7 @@
 #include <QVBoxLayout>
 
 #include "group_edit_widget.h"
+#include <moveit/move_group_interface/move_group_interface.h>
 #include <pluginlib/class_loader.hpp>  // for loading all avail kinematic planners
 
 namespace moveit_setup_assistant

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.h
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.h
@@ -75,6 +75,9 @@ public:
   QComboBox* kinematics_solver_field_;
   QLineEdit* kinematics_resolution_field_;
   QLineEdit* kinematics_timeout_field_;
+  QLineEdit* goal_joint_tolerance_field_;
+  QLineEdit* goal_position_tolerance_field_;
+  QLineEdit* goal_orientation_tolerance_field_;
   QLineEdit* kinematics_parameters_file_field_;
   QComboBox* default_planner_field_;
   QPushButton* btn_delete_;      // this button is hidden for new groups

--- a/moveit_setup_assistant/src/widgets/group_edit_widget.h
+++ b/moveit_setup_assistant/src/widgets/group_edit_widget.h
@@ -40,6 +40,7 @@
 class QComboBox;
 class QLabel;
 class QLineEdit;
+class QDoubleSpinBox;
 class QPushButton;
 
 #ifndef Q_MOC_RUN
@@ -51,6 +52,13 @@ namespace moveit_setup_assistant
 class GroupEditWidget : public QWidget
 {
   Q_OBJECT
+
+private:
+  const int FORM_CONTROL_WIDTH = 400;
+  const int DECIMALS_TOLERANCE = 4;
+  const double MIN_TOLERANCE = 1e-4;
+  const double MAX_TOLERANCE = 1.0;
+  const double STEP_TOLERANCE = 1e-4;
 
 public:
   // ******************************************************************************************
@@ -75,9 +83,9 @@ public:
   QComboBox* kinematics_solver_field_;
   QLineEdit* kinematics_resolution_field_;
   QLineEdit* kinematics_timeout_field_;
-  QLineEdit* goal_joint_tolerance_field_;
-  QLineEdit* goal_position_tolerance_field_;
-  QLineEdit* goal_orientation_tolerance_field_;
+  QDoubleSpinBox* goal_joint_tolerance_field_;
+  QDoubleSpinBox* goal_position_tolerance_field_;
+  QDoubleSpinBox* goal_orientation_tolerance_field_;
   QLineEdit* kinematics_parameters_file_field_;
   QComboBox* default_planner_field_;
   QPushButton* btn_delete_;      // this button is hidden for new groups

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -1055,6 +1055,9 @@ bool PlanningGroupsWidget::saveGroupScreen()
   const std::string& default_planner = group_edit_widget_->default_planner_field_->currentText().toStdString();
   const std::string& kinematics_resolution = group_edit_widget_->kinematics_resolution_field_->text().toStdString();
   const std::string& kinematics_timeout = group_edit_widget_->kinematics_timeout_field_->text().toStdString();
+  const std::string& goal_joint_tolerance = group_edit_widget_->goal_joint_tolerance_field_->text().toStdString();
+  const std::string& goal_position_tolerance = group_edit_widget_->goal_position_tolerance_field_->text().toStdString();
+  const std::string& goal_orientation_tolerance = group_edit_widget_->goal_orientation_tolerance_field_->text().toStdString();
   const std::string& kinematics_parameters_file =
       group_edit_widget_->kinematics_parameters_file_field_->text().toStdString();
 
@@ -1113,6 +1116,42 @@ bool PlanningGroupsWidget::saveGroupScreen()
     return false;
   }
 
+  // Check that goal joint tolerance is a double number
+  double goal_joint_tolerance_double;
+  try
+  {
+    goal_joint_tolerance_double = boost::lexical_cast<double>(goal_joint_tolerance);
+  }
+  catch (boost::bad_lexical_cast&)
+  {
+    QMessageBox::warning(this, "Error Saving", "Unable to convert goal joint tolerance to a double number.");
+    return false;
+  }
+
+  // Check that goal position tolerance is a double number
+  double goal_position_tolerance_double;
+  try
+  {
+    goal_position_tolerance_double = boost::lexical_cast<double>(goal_position_tolerance);
+  }
+  catch (boost::bad_lexical_cast&)
+  {
+    QMessageBox::warning(this, "Error Saving", "Unable to convert goal position tolerance to a double number.");
+    return false;
+  }
+
+  // Check that goal orientation tolerance is a double number
+  double goal_orientation_tolerance_double;
+  try
+  {
+    goal_orientation_tolerance_double = boost::lexical_cast<double>(goal_orientation_tolerance);
+  }
+  catch (boost::bad_lexical_cast&)
+  {
+    QMessageBox::warning(this, "Error Saving", "Unable to convert goal orientation tolerance to a double number.");
+    return false;
+  }
+
   // Check that all numbers are >0
   if (kinematics_resolution_double <= 0)
   {
@@ -1122,6 +1161,16 @@ bool PlanningGroupsWidget::saveGroupScreen()
   if (kinematics_timeout_double <= 0)
   {
     QMessageBox::warning(this, "Error Saving", "Kinematics solver search timeout must be greater than 0.");
+    return false;
+  }
+  if (goal_joint_tolerance_double <= 0)
+  {
+    QMessageBox::warning(this, "Error Saving", "Goal joint tolerance must be greater than 0.");
+    return false;
+  }
+  if (goal_position_tolerance_double <= 0)
+  {
+    QMessageBox::warning(this, "Error Saving", "Goal position tolerance must be greater than 0.");
     return false;
   }
 
@@ -1207,6 +1256,9 @@ bool PlanningGroupsWidget::saveGroupScreen()
   config_data_->group_meta_data_[group_name].kinematics_solver_ = kinematics_solver;
   config_data_->group_meta_data_[group_name].kinematics_solver_search_resolution_ = kinematics_resolution_double;
   config_data_->group_meta_data_[group_name].kinematics_solver_timeout_ = kinematics_timeout_double;
+  config_data_->group_meta_data_[group_name].goal_joint_tolerance_ = goal_joint_tolerance_double;
+  config_data_->group_meta_data_[group_name].goal_position_tolerance_ = goal_position_tolerance_double;
+  config_data_->group_meta_data_[group_name].goal_orientation_tolerance_ = goal_orientation_tolerance_double;
   config_data_->group_meta_data_[group_name].kinematics_parameters_file_ = kinematics_parameters_file;
   config_data_->group_meta_data_[group_name].default_planner_ = (default_planner == "None" ? "" : default_planner);
   config_data_->changes |= MoveItConfigData::GROUP_KINEMATICS;

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -58,6 +58,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QDoubleSpinBox>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QStackedWidget>
@@ -1055,9 +1056,9 @@ bool PlanningGroupsWidget::saveGroupScreen()
   const std::string& default_planner = group_edit_widget_->default_planner_field_->currentText().toStdString();
   const std::string& kinematics_resolution = group_edit_widget_->kinematics_resolution_field_->text().toStdString();
   const std::string& kinematics_timeout = group_edit_widget_->kinematics_timeout_field_->text().toStdString();
-  const std::string& goal_joint_tolerance = group_edit_widget_->goal_joint_tolerance_field_->text().toStdString();
-  const std::string& goal_position_tolerance = group_edit_widget_->goal_position_tolerance_field_->text().toStdString();
-  const std::string& goal_orientation_tolerance = group_edit_widget_->goal_orientation_tolerance_field_->text().toStdString();
+  double goal_joint_tolerance = group_edit_widget_->goal_joint_tolerance_field_->value();
+  double goal_position_tolerance = group_edit_widget_->goal_position_tolerance_field_->value();
+  double goal_orientation_tolerance = group_edit_widget_->goal_orientation_tolerance_field_->value();
   const std::string& kinematics_parameters_file =
       group_edit_widget_->kinematics_parameters_file_field_->text().toStdString();
 
@@ -1116,42 +1117,6 @@ bool PlanningGroupsWidget::saveGroupScreen()
     return false;
   }
 
-  // Check that goal joint tolerance is a double number
-  double goal_joint_tolerance_double;
-  try
-  {
-    goal_joint_tolerance_double = boost::lexical_cast<double>(goal_joint_tolerance);
-  }
-  catch (boost::bad_lexical_cast&)
-  {
-    QMessageBox::warning(this, "Error Saving", "Unable to convert goal joint tolerance to a double number.");
-    return false;
-  }
-
-  // Check that goal position tolerance is a double number
-  double goal_position_tolerance_double;
-  try
-  {
-    goal_position_tolerance_double = boost::lexical_cast<double>(goal_position_tolerance);
-  }
-  catch (boost::bad_lexical_cast&)
-  {
-    QMessageBox::warning(this, "Error Saving", "Unable to convert goal position tolerance to a double number.");
-    return false;
-  }
-
-  // Check that goal orientation tolerance is a double number
-  double goal_orientation_tolerance_double;
-  try
-  {
-    goal_orientation_tolerance_double = boost::lexical_cast<double>(goal_orientation_tolerance);
-  }
-  catch (boost::bad_lexical_cast&)
-  {
-    QMessageBox::warning(this, "Error Saving", "Unable to convert goal orientation tolerance to a double number.");
-    return false;
-  }
-
   // Check that all numbers are >0
   if (kinematics_resolution_double <= 0)
   {
@@ -1163,14 +1128,19 @@ bool PlanningGroupsWidget::saveGroupScreen()
     QMessageBox::warning(this, "Error Saving", "Kinematics solver search timeout must be greater than 0.");
     return false;
   }
-  if (goal_joint_tolerance_double <= 0)
+  if (goal_joint_tolerance <= 0)
   {
     QMessageBox::warning(this, "Error Saving", "Goal joint tolerance must be greater than 0.");
     return false;
   }
-  if (goal_position_tolerance_double <= 0)
+  if (goal_position_tolerance <= 0)
   {
     QMessageBox::warning(this, "Error Saving", "Goal position tolerance must be greater than 0.");
+    return false;
+  }
+  if (goal_orientation_tolerance <= 0)
+  {
+    QMessageBox::warning(this, "Error Saving", "Goal orientation tolerance must be greater than 0.");
     return false;
   }
 
@@ -1256,9 +1226,9 @@ bool PlanningGroupsWidget::saveGroupScreen()
   config_data_->group_meta_data_[group_name].kinematics_solver_ = kinematics_solver;
   config_data_->group_meta_data_[group_name].kinematics_solver_search_resolution_ = kinematics_resolution_double;
   config_data_->group_meta_data_[group_name].kinematics_solver_timeout_ = kinematics_timeout_double;
-  config_data_->group_meta_data_[group_name].goal_joint_tolerance_ = goal_joint_tolerance_double;
-  config_data_->group_meta_data_[group_name].goal_position_tolerance_ = goal_position_tolerance_double;
-  config_data_->group_meta_data_[group_name].goal_orientation_tolerance_ = goal_orientation_tolerance_double;
+  config_data_->group_meta_data_[group_name].goal_joint_tolerance_ = goal_joint_tolerance;
+  config_data_->group_meta_data_[group_name].goal_position_tolerance_ = goal_position_tolerance;
+  config_data_->group_meta_data_[group_name].goal_orientation_tolerance_ = goal_orientation_tolerance;
   config_data_->group_meta_data_[group_name].kinematics_parameters_file_ = kinematics_parameters_file;
   config_data_->group_meta_data_[group_name].default_planner_ = (default_planner == "None" ? "" : default_planner);
   config_data_->changes |= MoveItConfigData::GROUP_KINEMATICS;


### PR DESCRIPTION
### Description

MoveIt often fails to plan a valid path because goal joint position, goal position, and goal orientation tolerances are hard-coded as arbitrary/magic numbers. Other values in the same Move Group interface implementation are easily configurable.

These changes allow overriding the default (hard-coded) values of `0.1 millimeter` and `0.1 degree` in `kinematics.yaml` to relax the tolerances for debugging inverse kinematics or when using low-fidelity hardware such as potentiometers which jump by several degrees due to digital noise while reading arm joint positions.

The values made configurable by this pull request are:

* `moveit::planning_interface::MoveGroupInterface::MoveGroupInterfaceImpl::goal_joint_tolerance_`
  * Read from `goal_joint_tolerance` value in `kinematics.yaml` under the joint model group name
* `moveit::planning_interface::MoveGroupInterface::MoveGroupInterfaceImpl::goal_position_tolerance_`
  * Read from `goal_position_tolerance` value in `kinematics.yaml` under the joint model group name
* `moveit::planning_interface::MoveGroupInterface::MoveGroupInterfaceImpl::goal_orientation_tolerance_`
  * Read from `goal_orientation_tolerance` value in `kinematics.yaml` under the joint model group name

An example of overriding them in `kinematics.yaml` generated by MoveIt setup assistant:

```
arm
   goal_joint_tolerance: 0.1
   goal_position_tolerance: 0.1
   goal_orientation_tolerance: 0.1
```

This area of the code is not covered by tests, see https://github.com/ros-planning/moveit/blob/1249c2b183e557d502a50c135fa327f55f26fedf/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp

The constraint tolerance defaults in MoveIt appear to be completely undocumented. The closest help topic is https://ros-planning.github.io/moveit_tutorials/doc/kinematics_configuration/kinematics_configuration_tutorial.html, which could be updated to talk about these three new settings.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
