### PR TITLE
Improved Constraint Manifold

### DIFF
--- a/moveit_core/kinematic_constraints/src/utils.cpp
+++ b/moveit_core/kinematic_constraints/src/utils.cpp
@@ -414,6 +414,8 @@ static bool constructConstraint(XmlRpc::XmlRpcValue& params, moveit_msgs::Orient
       constraint.weight = parseDouble(it->second);
     else if (it->first == "link_name")
       constraint.link_name = static_cast<std::string>(it->second);
+    else if (it->first == "parameterization")
+      constraint.parameterization = static_cast<int>(it->second);
     else if (it->first == "orientation")
     {
       if (!isArray(it->second, 3, it->first, "RPY values"))

--- a/moveit_planners/ompl/ompl_interface/launch/generate_state_database.launch
+++ b/moveit_planners/ompl/ompl_interface/launch/generate_state_database.launch
@@ -2,11 +2,12 @@
   <arg name="use_current_scene" default="false"/>
   <arg name="planning_group"/>
   <arg name="constraints_file" doc="the path to a constraints yaml file (see generate_state_database for details)"/>
+	<arg name="output_folder" default="constraint_approximations_database"/>
 
   <node name="generate_state_database" pkg="moveit_planners_ompl" type="generate_state_database" output="screen">
     <param name="use_current_scene" value="$(arg use_current_scene)"/>
     <param name="planning_group" value="$(arg planning_group)"/>
-    <remap from="~output_folder" to="move_group/constraint_approximations_path"/>
+    <param name="output_folder" value="$(arg output_folder)"/>
 
     <rosparam ns="constraints" command="load" file="$(arg constraints_file)"/>
   </node>

--- a/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
+++ b/moveit_planners/ompl/ompl_interface/scripts/generate_state_database.cpp
@@ -159,6 +159,7 @@ void computeDB(const planning_scene::PlanningScenePtr& scene, struct GenerateSta
  *    link_name: tool0
  *    orientation: [0, 0, 0]
  *    tolerances: [0.01, 0.01, 3.15]
+ *    parameterization: 0
  *    weight: 1.0
  * "
  */


### PR DESCRIPTION
### Description

* Added `parameterization` field to orientation constraint in [saving](https://github.com/ros-planning/moveit/compare/master...leander-dsouza:moveit:improve-constraint-manifold?expand=1#diff-4e926ad94860a6b6c372df6ba70a0f16045d119819953a6988c9d3f80535e0a9R417) approximation constraint manifold.
* Settable `output folder` while [generating](https://github.com/ros-planning/moveit/compare/master...leander-dsouza:moveit:improve-constraint-manifold?expand=1#diff-f1e884c2e7ec385920907fb172040b2e78eb0ab96688cf2dbe8b9533f051738fR10) these constraints.
* I'll update the documentation as well for the `parameterization` field in the [tutorials](https://ros-planning.github.io/moveit_tutorials/doc/planning_with_approximated_constraint_manifolds/planning_with_approximated_constraint_manifolds_tutorial.html#orientationconstraint) once this PR gets merged.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
