### PR TITLE
Make XmlRpcValue arguments const references

### DIFF
--- a/moveit_core/utils/include/moveit/utils/xmlrpc_casts.h
+++ b/moveit_core/utils/include/moveit/utils/xmlrpc_casts.h
@@ -43,7 +43,7 @@ namespace moveit
 namespace core
 {
 /// parse a double value from a scalar XmlRpc
-double parseDouble(XmlRpc::XmlRpcValue& v);
+double parseDouble(const XmlRpc::XmlRpcValue& v);
 
 /** check that v is an array of given size
  *
@@ -51,13 +51,14 @@ double parseDouble(XmlRpc::XmlRpcValue& v);
  * @param name: if non-empty, print a warning message "name is not an array[size]"
  * @param description: if non-empty, serves as a descriptor for array items
  */
-bool isArray(XmlRpc::XmlRpcValue& v, size_t size = 0, const std::string& name = "", const std::string& description = "");
+bool isArray(const XmlRpc::XmlRpcValue& v, size_t size = 0, const std::string& name = "",
+             const std::string& description = "");
 
 /** check that v is a struct with given keys
  *
  * @param keys: list of required keys
  * @param name: if non-empty, print a warning message "name is not a struct with keys ..."
  */
-bool isStruct(XmlRpc::XmlRpcValue& v, const std::vector<std::string>& keys = {}, const std::string& name = "");
+bool isStruct(const XmlRpc::XmlRpcValue& v, const std::vector<std::string>& keys = {}, const std::string& name = "");
 }  // namespace core
 }  // namespace moveit

--- a/moveit_core/utils/src/xmlrpc_casts.cpp
+++ b/moveit_core/utils/src/xmlrpc_casts.cpp
@@ -42,7 +42,7 @@ namespace moveit
 {
 namespace core
 {
-double parseDouble(XmlRpc::XmlRpcValue& v)
+double parseDouble(const XmlRpc::XmlRpcValue& v)
 {
   if (v.getType() == XmlRpc::XmlRpcValue::TypeDouble)
     return static_cast<double>(v);
@@ -52,7 +52,7 @@ double parseDouble(XmlRpc::XmlRpcValue& v)
     return 0.0;
 }
 
-bool isArray(XmlRpc::XmlRpcValue& v, size_t size, const std::string& name, const std::string& description)
+bool isArray(const XmlRpc::XmlRpcValue& v, size_t size, const std::string& name, const std::string& description)
 {
   if (v.getType() != XmlRpc::XmlRpcValue::TypeArray || (size != 0 && static_cast<size_t>(v.size()) != size))
   {
@@ -64,7 +64,7 @@ bool isArray(XmlRpc::XmlRpcValue& v, size_t size, const std::string& name, const
   return true;
 }
 
-bool isStruct(XmlRpc::XmlRpcValue& v, const std::vector<std::string>& keys, const std::string& name)
+bool isStruct(const XmlRpc::XmlRpcValue& v, const std::vector<std::string>& keys, const std::string& name)
 {
   if (v.getType() != XmlRpc::XmlRpcValue::TypeStruct)
   {


### PR DESCRIPTION
This was broken upstream before, but seems to be fixed now (https://github.com/ros/ros_comm/pull/1978)