### PR TITLE
Fix planar joint Jacobian bug

### DIFF
--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -25,6 +25,9 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
   target_link_libraries(test_robot_state ${MOVEIT_LIB_NAME} moveit_test_utils)
 
+  catkin_add_gtest(test_planar_joint_jacobian test/test_planar_joint_jacobian.cpp)
+  target_link_libraries(test_planar_joint_jacobian ${MOVEIT_LIB_NAME} moveit_test_utils)
+
   # As an executable, this benchmark is not run as a test by default
   add_executable(robot_state_benchmark test/robot_state_benchmark.cpp)
   target_link_libraries(robot_state_benchmark ${MOVEIT_LIB_NAME} moveit_test_utils ${GTEST_LIBRARIES})
@@ -33,11 +36,6 @@ if(CATKIN_ENABLE_TESTING)
     test/test_cartesian_interpolator.test
     test/test_cartesian_interpolator.cpp)
   target_link_libraries(test_cartesian_interpolator ${MOVEIT_LIB_NAME} moveit_test_utils)
-
-  add_rostest_gtest(test_planar_joint_jacobian
-    test/test_planar_joint_jacobian.test
-    test/test_planar_joint_jacobian.cpp)
-  target_link_libraries(test_planar_joint_jacobian ${MOVEIT_LIB_NAME} moveit_test_utils)
 
   catkin_add_gtest(test_robot_state_complex test/test_kinematic_complex.cpp)
   target_link_libraries(test_robot_state_complex ${MOVEIT_LIB_NAME} moveit_test_utils)

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -34,6 +34,11 @@ if(CATKIN_ENABLE_TESTING)
     test/test_cartesian_interpolator.cpp)
   target_link_libraries(test_cartesian_interpolator ${MOVEIT_LIB_NAME} moveit_test_utils)
 
+  add_rostest_gtest(test_planar_joint_jacobian
+    test/test_planar_joint_jacobian.test
+    test/test_planar_joint_jacobian.cpp)
+  target_link_libraries(test_planar_joint_jacobian ${MOVEIT_LIB_NAME} moveit_test_utils)
+
   catkin_add_gtest(test_robot_state_complex test/test_kinematic_complex.cpp)
   target_link_libraries(test_robot_state_complex ${MOVEIT_LIB_NAME} moveit_test_utils)
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1371,11 +1371,11 @@ bool RobotState::getJacobian(const JointModelGroup* group, const LinkModel* link
       }
       else if (pjm->getType() == moveit::core::JointModel::PLANAR)
       {
-        joint_axis = joint_transform * Eigen::Vector3d(1.0, 0.0, 0.0);
+        joint_axis = joint_transform.linear() * Eigen::Vector3d(1.0, 0.0, 0.0);
         jacobian.block<3, 1>(0, joint_index) = jacobian.block<3, 1>(0, joint_index) + joint_axis;
-        joint_axis = joint_transform * Eigen::Vector3d(0.0, 1.0, 0.0);
+        joint_axis = joint_transform.linear() * Eigen::Vector3d(0.0, 1.0, 0.0);
         jacobian.block<3, 1>(0, joint_index + 1) = jacobian.block<3, 1>(0, joint_index + 1) + joint_axis;
-        joint_axis = joint_transform * Eigen::Vector3d(0.0, 0.0, 1.0);
+        joint_axis = joint_transform.linear() * Eigen::Vector3d(0.0, 0.0, 1.0);
         jacobian.block<3, 1>(0, joint_index + 2) = jacobian.block<3, 1>(0, joint_index + 2) +
                                                    joint_axis.cross(point_transform - joint_transform.translation());
         jacobian.block<3, 1>(3, joint_index + 2) = jacobian.block<3, 1>(3, joint_index + 2) + joint_axis;

--- a/moveit_core/robot_state/test/test_planar_joint_jacobian.cpp
+++ b/moveit_core/robot_state/test/test_planar_joint_jacobian.cpp
@@ -82,8 +82,7 @@ TEST_F(SimplePlanarRobot, testSimplePlanarRobot)
   //-----------------------Move first axis to 10 m-----------------------
   q_test[0] = 10.0;
   //-----------------------Set robot state-----------------------
-  robot_state_->setJointGroupPositions(joint_model_group, 
-                                       q_test);
+  robot_state_->setJointGroupPositions(joint_model_group, q_test);
   robot_state_->updateLinkTransforms();
 
   //-----------------------Calculate Jacobian-----------------------

--- a/moveit_core/robot_state/test/test_planar_joint_jacobian.cpp
+++ b/moveit_core/robot_state/test/test_planar_joint_jacobian.cpp
@@ -98,6 +98,5 @@ TEST_F(SimplePlanarRobot, testSimplePlanarRobot)
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "test_planar_joint_jacobian");
   return RUN_ALL_TESTS();
 }

--- a/moveit_core/robot_state/test/test_planar_joint_jacobian.cpp
+++ b/moveit_core/robot_state/test/test_planar_joint_jacobian.cpp
@@ -1,0 +1,110 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2019, PickNik LLC.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the PickNik nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Ivo Vatavuk */
+
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <moveit/robot_state/cartesian_interpolator.h>
+#include <moveit/utils/robot_model_test_utils.h>
+#include <moveit/utils/eigen_test_utils.h>
+
+using namespace moveit::core;
+
+class SimplePlanarRobot : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    RobotModelBuilder builder("simple", "a");
+    builder.addChain("a->b", "planar");
+    builder.addGroupChain("a", "b", "group");
+    robot_model_ = builder.build();
+    robot_state_ = std::make_shared<RobotState>(robot_model_);
+  }
+
+  void TearDown() override
+  {
+  }
+
+protected:
+  RobotModelPtr robot_model_;
+  RobotStatePtr robot_state_;
+};
+
+TEST_F(SimplePlanarRobot, testSimplePlanarRobot)
+{
+  std::cout << "Testing simple planar robot jacobian\n";
+
+  Eigen::Vector3d reference_point_position(0.0, 0.0, 0.0);
+  auto joint_model_group = robot_model_->getJointModelGroup("group");
+
+  std::vector<double> q_test{0.0, 0.0, 0.0};
+  //-----------------------Set robot state-----------------------
+  robot_state_->setJointGroupPositions(joint_model_group, 
+                                       q_test);
+  robot_state_->updateLinkTransforms();
+
+  //-----------------------Calculate Jacobian-----------------------
+  Eigen::MatrixXd jacobian;
+  robot_state_->getJacobian(joint_model_group,
+                            robot_state_->getLinkModel("b"),
+                            reference_point_position, jacobian);
+
+  //-----------------------Move first axis to 10 m-----------------------
+  q_test[0] = 10.0;
+  //-----------------------Set robot state-----------------------
+  robot_state_->setJointGroupPositions(joint_model_group, 
+                                       q_test);
+  robot_state_->updateLinkTransforms();
+
+  //-----------------------Calculate Jacobian-----------------------
+  Eigen::MatrixXd jacobian_2;
+  robot_state_->getJacobian(joint_model_group,
+                            robot_state_->getLinkModel("b"),
+                            reference_point_position, jacobian_2);
+
+
+  std::cout << "First Jacobian = \n" << jacobian << "\n";
+  std::cout << "Second Jacobian = \n" << jacobian_2 << "\n";
+
+  EXPECT_EIGEN_NEAR(jacobian, jacobian_2, 1e-5);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_planar_joint_jacobian");
+  return RUN_ALL_TESTS();
+}

--- a/moveit_core/robot_state/test/test_planar_joint_jacobian.cpp
+++ b/moveit_core/robot_state/test/test_planar_joint_jacobian.cpp
@@ -70,17 +70,14 @@ TEST_F(SimplePlanarRobot, testSimplePlanarRobot)
   Eigen::Vector3d reference_point_position(0.0, 0.0, 0.0);
   auto joint_model_group = robot_model_->getJointModelGroup("group");
 
-  std::vector<double> q_test{0.0, 0.0, 0.0};
+  std::vector<double> q_test{ 0.0, 0.0, 0.0 };
   //-----------------------Set robot state-----------------------
-  robot_state_->setJointGroupPositions(joint_model_group, 
-                                       q_test);
+  robot_state_->setJointGroupPositions(joint_model_group, q_test);
   robot_state_->updateLinkTransforms();
 
   //-----------------------Calculate Jacobian-----------------------
   Eigen::MatrixXd jacobian;
-  robot_state_->getJacobian(joint_model_group,
-                            robot_state_->getLinkModel("b"),
-                            reference_point_position, jacobian);
+  robot_state_->getJacobian(joint_model_group, robot_state_->getLinkModel("b"), reference_point_position, jacobian);
 
   //-----------------------Move first axis to 10 m-----------------------
   q_test[0] = 10.0;
@@ -91,10 +88,7 @@ TEST_F(SimplePlanarRobot, testSimplePlanarRobot)
 
   //-----------------------Calculate Jacobian-----------------------
   Eigen::MatrixXd jacobian_2;
-  robot_state_->getJacobian(joint_model_group,
-                            robot_state_->getLinkModel("b"),
-                            reference_point_position, jacobian_2);
-
+  robot_state_->getJacobian(joint_model_group, robot_state_->getLinkModel("b"), reference_point_position, jacobian_2);
 
   std::cout << "First Jacobian = \n" << jacobian << "\n";
   std::cout << "Second Jacobian = \n" << jacobian_2 << "\n";

--- a/moveit_core/robot_state/test/test_planar_joint_jacobian.test
+++ b/moveit_core/robot_state/test/test_planar_joint_jacobian.test
@@ -1,3 +1,0 @@
-<launch>
-	<test pkg="moveit_core" type="test_planar_joint_jacobian" test-name="test_planar_joint_jacobian" />
-</launch>

--- a/moveit_core/robot_state/test/test_planar_joint_jacobian.test
+++ b/moveit_core/robot_state/test/test_planar_joint_jacobian.test
@@ -1,0 +1,3 @@
+<launch>
+	<test pkg="moveit_core" type="test_planar_joint_jacobian" test-name="test_planar_joint_jacobian" />
+</launch>


### PR DESCRIPTION
### Description

While working on [this](https://github.com/ros-planning/moveit/issues/3436) I think I found a bug in Jacobian calculation for planar joints. 

The fix is simple, in lines performing `joint_axis` calculation, instead of `joint_transform`, `joint_transform.linear()` should be used, like for the other joint types. 

I've written a simple test, I don't think it needs to be merged, but it demonstrates the bug so you can check it.
For the example in the test, current `getJacobian` implementation calculates the `joint_axis` of the first joint to be [1, 0, 0]^T when q[0] = 0, and [11, 0, 0]^T when q[0] = 10, which results in different `Jacobian` values. 
