### PR TITLE
Fix segfault when planning with differential drive planar joints

### DIFF
--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -174,15 +174,7 @@ void computeTurnDriveTurnGeometry(const double* from, const double* to, const do
     initial_turn = angle_backward_diff;
   }
   drive_angle = from[2] + initial_turn;
-  final_turn = to[2] - drive_angle;
-
-  // Check if normalization is needed, because
-  // if fabs(final_turn) << M_PI, the floating point arithmetic performed in `normalize_angle`
-  // will cause final_turn to be rounded to 0
-  if (final_turn < -boost::math::constants::pi<double>() || final_turn >= boost::math::constants::pi<double>())
-  {
-    final_turn = angles::normalize_angle(final_turn);
-  }
+  final_turn = angles::shortest_angular_distance(drive_angle, to[2]);
 }
 
 void PlanarJointModel::interpolate(const double* from, const double* to, const double t, double* state) const
@@ -229,7 +221,7 @@ void PlanarJointModel::interpolate(const double* from, const double* to, const d
     // If the difference between `from` and `to` is so low that it is within floating point arithmetic error
     // or if `from == to`, the following operations will result in nan
     // Just set the return state to target state and don't interpolate.
-    if (total_d == 0.0)
+    if (total_d < std::numeric_limits<float>::epsilon())
     {
       state[0] = to[0];
       state[1] = to[1];


### PR DESCRIPTION
### Description

In my previous PR #3359, where I backported differential drive from MoveIt2, I noted in the "Open Issues with Differential Drive Planning in MoveIt" section that:

> When moveit_core is built as Debug, if the goal position of the base is rotated using the Rviz gui, the ASSERT_ISOMETRY [here](https://github.com/ros-planning/moveit/blob/326e9b5fe76bdf856f9c4a2be56ce7e136651ff2/moveit_core/robot_model/src/planar_joint_model.cpp#L228) fails and crashes the program. Despite this issue, when we build the package as Release, no error is reported and things seem to work correctly even if the assertion condition is not met.

In further testing, I also noticed that RRT* was segfaulting intermittently after generating 100 or so plans. It turns out these two issues are interconnected.

#### Root Cause

- In a rare case when two states passed into `interpolate` are very close to each other, the result of [`angles::normalize_angle()`](https://github.com/ros/angles/blob/54ad72b0ce473a2e1d98da447898bf2fcd36519f/angles/include/angles/angles.h#L84C1-L89) called by [`angles::shortest_angular_distance()`](https://github.com/ros/angles/blob/54ad72b0ce473a2e1d98da447898bf2fcd36519f/angles/include/angles/angles.h#L104-L107) which is called by [`computeTurnDriveTurnGeometry()`](https://github.com/scchow/moveit/blob/69ca441bc343c51544b19dde9c5a095481a3d906/moveit_core/robot_model/src/planar_joint_model.cpp#L177C11-L177C11) will round to `0.0` due to floating point arithmetic truncation when `M_PI` is first added to, then subtracted from the angle difference.
- The result of this is used in the `interpolate()` as the divisor for splitting the path into [turn, drive, turn phases](https://github.com/scchow/moveit/blob/69ca441bc343c51544b19dde9c5a095481a3d906/moveit_core/robot_model/src/planar_joint_model.cpp#L217-L219). If there is also no `x`, `y`, and `z` displacement, this results in a divide-by-zero operation (`0.0/0.0`), which C++ helpfully sets the result as `nan` without throwing any errors.
- This `nan` is then used in subsequent state calculations, causing both the `ASSERT_ISOMETRY` error noticed in my prior PR when the package is built as debug and eventually culminating in a segfault.

#### Fixes

To fix this issue, I added:
- a check to only normalize the angle when the angle difference is sufficiently large which avoids unnecessary floating point truncation.
- a check for if the states are the same, which will cause interpolate to just return the final state to avoid additional divide-by-zero errors.

### Implication on ROS 2 Implementation

As far as I know, this same error should also occur in moveit2. I am currently setting up a ROS2 container to test this and will submit a follow up PR if it turns out to be susceptible to the same issue.

### Remaining Issues
After solving this problem, I've encountered another issue that arises when compiling with the debug flag set. When visualizing the geometry of a robot with a differential drive base using Rviz, we run into a separate assertion error which is caused by this line in the [RViz Plugin](https://github.com/ros-planning/moveit/blame/69ca441bc343c51544b19dde9c5a095481a3d906/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp#L336). The backtrace can be found [here](https://pastebin.com/TjVDax45). This appears to be a completely separate issue, and I will have to debug this separately. This issue does not seem to appear when things are compiled with release.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
