### PR TITLE
Update target robot state before calling setFromIK in MoveGroupInterface setJointValueTarget

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -494,6 +494,9 @@ public:
       kinematics::KinematicsQueryOptions o;
       o.return_approximate_solution = approx;
 
+      // robot state needs to be updated before calling setFromIK since commit 6426c74 (PR #3388)
+      getTargetRobotState().update();
+
       // if no frame transforms are needed, call IK directly
       if (frame.empty() || moveit::core::Transforms::sameFrame(frame, getRobotModel()->getModelFrame()))
         return getTargetRobotState().setFromIK(getJointModelGroup(), eef_pose, eef, 0.0,


### PR DESCRIPTION
This is necessary since commit 6426c74 (PR #3388). Fixes #3467.
