### PR TITLE
Fixup #3388

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/robot_model.h
@@ -271,7 +271,14 @@ public:
    * will actually warp wrist (and all its descendants).
    */
   static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
+                                                                           Eigen::Isometry3d& transform,
                                                                            const JointModelGroup* jmg = nullptr);
+  static const moveit::core::LinkModel* getRigidlyConnectedParentLinkModel(const LinkModel* link,
+                                                                           const JointModelGroup* jmg = nullptr)
+  {
+    Eigen::Isometry3d unused;
+    return getRigidlyConnectedParentLinkModel(link, unused, jmg);
+  }
 
   /** \brief Get the array of links  */
   const std::vector<const LinkModel*>& getLinkModels() const

--- a/moveit_core/robot_model/src/robot_model.cpp
+++ b/moveit_core/robot_model/src/robot_model.cpp
@@ -1265,10 +1265,13 @@ LinkModel* RobotModel::getLinkModel(const std::string& name, bool* has_link)
   return nullptr;
 }
 
-const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link, const JointModelGroup* jmg)
+const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel* link, Eigen::Isometry3d& transform,
+                                                                const JointModelGroup* jmg)
 {
   if (!link)
     return link;
+
+  transform.setIdentity();
   const moveit::core::LinkModel* parent_link = link->getParentLinkModel();
   const moveit::core::JointModel* joint = link->getParentJointModel();
   decltype(jmg->getJointModels().cbegin()) begin{}, end{};
@@ -1289,6 +1292,7 @@ const LinkModel* RobotModel::getRigidlyConnectedParentLinkModel(const LinkModel*
 
   while (parent_link && is_fixed_or_not_in_jmg(joint))
   {
+    transform = link->getJointOriginTransform() * transform;
     link = parent_link;
     joint = link->getParentJointModel();
     parent_link = joint->getParentLinkModel();

--- a/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/attached_body.h
@@ -175,13 +175,6 @@ public:
    * The returned transform is guaranteed to be a valid isometry. */
   const Eigen::Isometry3d& getSubframeTransform(const std::string& frame_name, bool* found = nullptr) const;
 
-  /** \brief Get the fixed transform to a named subframe on this body (relative to the robot link)
-   *
-   * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
-   * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).
-   * The returned transform is guaranteed to be a valid isometry. */
-  const Eigen::Isometry3d& getSubframeTransformInLinkFrame(const std::string& frame_name, bool* found = nullptr) const;
-
   /** \brief Get the fixed transform to a named subframe on this body, relative to the world frame.
    * The frame_name needs to have the object's name prepended (e.g. "screwdriver/tip" returns true if the object's
    * name is "screwdriver"). Returns an identity transform if frame_name is unknown (and set found to false).

--- a/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/robot_state.h
@@ -1379,7 +1379,7 @@ public:
    * This behaves the same as RobotModel::getRigidlyConnectedParentLinkModel,
    * but can additionally resolve parents for attached objects / subframes.
    *
-   * If transform is specified, return the relative transform from the returned parent link to frame.
+   * If transform is specified, return the (fixed) relative transform from the returned parent link to frame.
    */
   const moveit::core::LinkModel*
   getRigidlyConnectedParentLinkModel(const std::string& frame, Eigen::Isometry3d* transform = nullptr,

--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -160,10 +160,7 @@ double CartesianInterpolator::computeCartesianPath(RobotState* start_state, cons
     // Explicitly use a single IK attempt only: We want a smooth trajectory.
     // Random seeding (of additional attempts) would probably create IK jumps.
     if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options))
-    {
-      start_state->update();
       traj.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
-    }
     else
       break;
 

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -1656,6 +1656,9 @@ bool RobotState::setFromIK(const JointModelGroup* jmg, const EigenSTL::vector_Is
   else if (consistency_limit_sets.size() == 1)
     consistency_limits = consistency_limit_sets[0];
 
+  // ensure RobotState is up-to-date before employing it in the IK solver
+  update(false);
+
   const std::vector<std::string>& solver_tip_frames = solver->getTipFrames();
 
   // Track which possible tips frames we have filled in so far

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -809,36 +809,38 @@ const LinkModel* RobotState::getRigidlyConnectedParentLinkModel(const std::strin
     if (!hasAttachedBody(object))
       return nullptr;
     auto body{ getAttachedBody(object) };
-    if (!body->hasSubframeTransform(frame))
-      return nullptr;
+    bool found = false;
     if (transform)
-      *transform = body->getGlobalSubframeTransform(frame);
+      *transform = body->getSubframeTransform(frame, &found);
+    else
+      body->getSubframeTransform(frame, &found);
+    if (!found)
+      return nullptr;
+    if (transform)  // prepend the body transform
+      *transform = body->getPose() * *transform;
     link = body->getAttachedLink();
   }
   else if (hasAttachedBody(frame))
   {
     auto body{ getAttachedBody(frame) };
     if (transform)
-      *transform = body->getGlobalPose();
+      *transform = body->getPose();
     link = body->getAttachedLink();
   }
   else if (getRobotModel()->hasLinkModel(frame))
   {
     link = getLinkModel(frame);
     if (transform)
-    {
-      BOOST_VERIFY(checkLinkTransforms());
-      *transform = global_link_transforms_[link->getLinkIndex()];
-    }
+      transform->setIdentity();
+    if (!link)
+      return nullptr;
   }
   // link is valid and transform describes pose of frame w.r.t. global frame
-  auto* parent = getRobotModel()->getRigidlyConnectedParentLinkModel(link, jmg);
+  Eigen::Isometry3d link_transform;
+  auto* parent = getRobotModel()->getRigidlyConnectedParentLinkModel(link, link_transform, jmg);
   if (parent && transform)
-  {
-    BOOST_VERIFY(checkLinkTransforms());
-    // compute transform from parent link to frame
-    *transform = global_link_transforms_[parent->getLinkIndex()].inverse() * *transform;
-  }
+    // prepend link_transform to get transform from parent link to frame
+    *transform = link_transform * *transform;
   return parent;
 }
 

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -686,7 +686,6 @@ TEST_F(OneRobot, rigidlyConnectedParent)
   EXPECT_EQ(robot_model_->getRigidlyConnectedParentLinkModel(link_b), link_a);
 
   moveit::core::RobotState state(robot_model_);
-  state.update();
 
   Eigen::Isometry3d a_to_b;
   EXPECT_EQ(state.getRigidlyConnectedParentLinkModel("link_b", &a_to_b), link_a);

--- a/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
+++ b/moveit_ros/planning_interface/test/move_group_interface_cpp_test.cpp
@@ -345,6 +345,18 @@ TEST_F(MoveGroupTestFixture, JointSpaceGoalTest)
   testJointPositions(plan_joint_positions);
 }
 
+TEST_F(MoveGroupTestFixture, CartesianGoalTest)
+{
+  move_group_->setPoseReferenceFrame("world");
+  move_group_->setEndEffectorLink("panda_hand");
+  geometry_msgs::Pose pose;
+  pose.position.x = 0.417;
+  pose.position.y = 0.240;
+  pose.position.z = 0.532;
+  pose.orientation.w = 1.0;
+  EXPECT_TRUE(move_group_->setJointValueTarget(pose));
+}
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "move_group_interface_cpp_test");


### PR DESCRIPTION
The implementation of #3388 relied on an up-to-date RobotState to compute the relative transform in `getRigidlyConnectedParentLinkModel()`. However, as these transforms are all fixed, we are able to compute the transform from those fixed relative transforms only, w/o the need for updated global transforms.
Fixes #3467.