### PR TITLE
Avoid costly updates of RobotInteraction on query state changes if they are not shown

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1245,14 +1245,16 @@ void MotionPlanningDisplay::updateQueryStates(const moveit::core::RobotState& cu
   {
     moveit::core::RobotState start = *getQueryStartState();
     updateStateExceptModified(start, current_state);
-    setQueryStartState(start);
+    if (query_start_state_property_->getBool())
+      setQueryStartState(start);
   }
 
   if (query_goal_state_)
   {
     moveit::core::RobotState goal = *getQueryGoalState();
     updateStateExceptModified(goal, current_state);
-    setQueryGoalState(goal);
+    if (query_goal_state_property_->getBool())
+      setQueryGoalState(goal);
   }
 }
 


### PR DESCRIPTION
This partially reverts d98a529a28ffe9bc283abe70828388a5b5b48c59, however, still updates the query states themselves.
