### PR TITLE
Fix typo in create_ikfast_moveit_plugin.py, line 430

### DIFF
--- a/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
+++ b/moveit_kinematics/ikfast_kinematics_plugin/scripts/create_ikfast_moveit_plugin.py
@@ -427,7 +427,7 @@ def update_moveit_package(args):
             )
 
         groups = [g.get("name") for g in srdf.findall("group")]
-        if args.planing_group_name not in groups:
+        if args.planning_group_name not in groups:
             raise RuntimeWarning(
                 f"Planning group '{args.planning_group_name}' not defined in the SRDF."
                 " Available groups: \n" + ", ".join(groups)


### PR DESCRIPTION
Fixed typo in line 430 of create_ikfast_moveit_plugin.py. Changed "planing_group_name" to "planning_group_name"

Terminal message fixed: 
'Namespace' object has no attribute "planing_group_name'

### Description

When trying to run `create_ikfast_moveit_plugin.py`, I received a terminal error message:
```
Failed to update MoveIt Package:
'Namespace' object has no attribute 'planing_group_name'
```

I looked into the .py and noticed it was a recent typo on line 430: planing to planning

I tested my fix, and the error went away. Created a pull request.

### Checklist
- [n/a] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [n/a] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [n/a] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [n/a] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [n/a] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
