### PR TITLE
moveit_core: make angles a build_depend rather than a test_depend

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -86,6 +86,7 @@ COMPONENTS
   xmlrpcpp
   pybind11_catkin
   pluginlib
+  angles
 )
 
 catkin_python_setup()

--- a/moveit_core/constraint_samplers/CMakeLists.txt
+++ b/moveit_core/constraint_samplers/CMakeLists.txt
@@ -26,10 +26,9 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
   find_package(orocos_kdl REQUIRED)
-  find_package(angles REQUIRED)
   find_package(tf2_kdl REQUIRED)
   find_package(rostest REQUIRED)
-  include_directories(SYSTEM ${orocos_kdl_INCLUDE_DIRS} ${angles_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS})
+  include_directories(SYSTEM ${orocos_kdl_INCLUDE_DIRS} ${tf2_kdl_INCLUDE_DIRS})
 
   add_rostest_gtest(test_constraint_samplers
     test/constraint_samplers.test
@@ -43,7 +42,6 @@ if(CATKIN_ENABLE_TESTING)
     gmock_main
     ${MOVEIT_LIB_NAME}
     ${catkin_LIBRARIES}
-    ${angles_LIBRARIES}
     ${orocos_kdl_LIBRARIES}
     ${urdfdom_LIBRARIES}
     ${urdfdom_headers_LIBRARIES}

--- a/moveit_core/package.xml
+++ b/moveit_core/package.xml
@@ -55,12 +55,12 @@
   <depend>visualization_msgs</depend>
   <depend>xmlrpcpp</depend>
   <depend>pluginlib</depend>
+  <build_depend>angles</build_depend>
 
   <doc_depend>python3-sphinx-rtd-theme</doc_depend>
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
   <test_depend>moveit_resources_pr2_description</test_depend>
-  <test_depend>angles</test_depend>
   <test_depend>tf2_kdl</test_depend>
   <test_depend condition="$ROS_DISTRO != noetic">orocos_kdl</test_depend>
   <test_depend condition="$ROS_DISTRO == noetic">liborocos-kdl-dev</test_depend>


### PR DESCRIPTION
### Description

Since https://github.com/ros-planning/moveit/commit/6c5203338bf305e1a9303839ded3afebee423c78, `angles.h` is included in `moveit_core/robot_model/src/planar_joint_model.cpp`, and therefore `angles` must be more than a `test_depend`. Since the C++ `angles` library is header only, I made it a `build_depend`.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
