### PR TITLE
fix apt check in docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,11 +35,10 @@ jobs:
           image: ${{ env.IMAGE }}
           run: |
             apt-get update
-            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
-            echo "no_cache=$have_updates" >> "$GITHUB_OUTPUT"
+            apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && exit 0 || exit 1)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outcome != 'success' }}
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
@@ -47,12 +46,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v5
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outcome != 'success' }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ matrix.ROS_DISTRO }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          no-cache: ${{ steps.apt.outcome != 'success' || github.event_name == 'workflow_dispatch' }}
           cache-from: type=registry,ref=${{ env.IMAGE }}
           cache-to: type=inline
           tags: ${{ env.IMAGE }}
@@ -79,11 +78,10 @@ jobs:
           image: ${{ env.IMAGE }}
           run: |
             apt-get update
-            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
-            echo "no_cache=$have_updates" >> "$GITHUB_OUTPUT"
+            apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && exit 0 || exit 1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outcome != 'success' }}
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
@@ -91,12 +89,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v5
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outcome != 'success' }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: ROS_DISTRO=${{ env.ROS_DISTRO }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          no-cache: ${{ steps.apt.outcome != 'success' || github.event_name == 'workflow_dispatch' }}
           cache-from: type=registry,ref=${{ env.IMAGE }}
           cache-to: type=inline
           tags: |
@@ -125,11 +123,10 @@ jobs:
           image: ${{ env.IMAGE }}
           run: |
             apt-get update
-            have_updates=$(apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && echo false || echo true)
-            echo "no_cache=$have_updates" >> "$GITHUB_OUTPUT"
+            apt-get --simulate upgrade | grep -q "^0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.$" && exit 0 || exit 1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outcome != 'success' }}
       - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
@@ -137,12 +134,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and Push
         uses: docker/build-push-action@v5
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outputs.no_cache }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name != 'schedule' || steps.apt.outcome != 'success' }}
         with:
           file: .docker/${{ github.job }}/Dockerfile
           build-args: IMAGE=${{ matrix.IMAGE }}
           push: true
-          no-cache: ${{ steps.apt.outputs.no_cache || github.event_name == 'workflow_dispatch' }}
+          no-cache: ${{ steps.apt.outcome != 'success' || github.event_name == 'workflow_dispatch' }}
           cache-from: type=registry,ref=${{ env.IMAGE }}
           cache-to: type=inline
           tags: |


### PR DESCRIPTION
### Description

Apparently this check isn't working:

https://github.com/ros-planning/moveit/blob/f8241d8e9b6bbd1c238bf30606414da3ef018182/.github/workflows/docker.yaml#L30-L39

it seems that `echo "no_cache=$have_updates" >> "$GITHUB_OUTPUT"` is not working anymore, and `steps.apt.outputs.no_cache` is always `null`.

So the apt packages status of the image currently has no influence on whether it is rebuilt. 


To fix this issue, this PR, for all jobs using this step, changes the exit value, i.e., the outcome of the job's step, and uses the outcome variable for later checks.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
