### PR TITLE
consider distance field padding for spheres

### DIFF
--- a/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
+++ b/moveit_core/collision_distance_field/src/collision_distance_field_types.cpp
@@ -49,11 +49,11 @@ collision_detection::determineCollisionSpheres(const bodies::Body* body, Eigen::
   std::vector<collision_detection::CollisionSphere> css;
   if (body->getType() == shapes::ShapeType::SPHERE)
   {
-    const auto radius = body->getDimensions()[0];
-    if (radius > 0.0)
+    bodies::BoundingSphere bsphere;
+    body->computeBoundingSphere(bsphere);
+    if (bsphere.radius > 0.0)
     {
-      collision_detection::CollisionSphere cs(body->getPose().translation(), radius);
-      css.push_back(cs);
+      css.push_back(collision_detection::CollisionSphere{ bsphere.center, bsphere.radius });
     }
   }
   else

--- a/moveit_core/planning_scene/test/test_planning_scene.cpp
+++ b/moveit_core/planning_scene/test/test_planning_scene.cpp
@@ -53,7 +53,7 @@
 TEST(PlanningScene, LoadRestore)
 {
   urdf::ModelInterfaceSharedPtr urdf_model = moveit::core::loadModelInterface("pr2");
-  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  auto srdf_model = std::make_shared<srdf::Model>();
   planning_scene::PlanningScene ps(urdf_model, srdf_model);
   moveit_msgs::PlanningScene ps_msg;
   ps.getPlanningSceneMsg(ps_msg);
@@ -67,7 +67,7 @@ TEST(PlanningScene, LoadRestore)
 TEST(PlanningScene, LoadOctomap)
 {
   urdf::ModelInterfaceSharedPtr urdf_model = moveit::core::loadModelInterface("pr2");
-  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  auto srdf_model = std::make_shared<srdf::Model>();
   planning_scene::PlanningScene ps(urdf_model, srdf_model);
 
   {  // check octomap before doing any operations on it
@@ -120,7 +120,7 @@ TEST(PlanningScene, LoadOctomap)
 TEST(PlanningScene, LoadRestoreDiff)
 {
   urdf::ModelInterfaceSharedPtr urdf_model = moveit::core::loadModelInterface("pr2");
-  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  auto srdf_model = std::make_shared<srdf::Model>();
   auto ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
 
   collision_detection::World& world = *ps->getWorldNonConst();
@@ -180,7 +180,7 @@ TEST(PlanningScene, LoadRestoreDiff)
 TEST(PlanningScene, MakeAttachedDiff)
 {
   urdf::ModelInterfaceSharedPtr urdf_model = moveit::core::loadModelInterface("pr2");
-  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  auto srdf_model = std::make_shared<srdf::Model>();
   auto ps = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
 
   /* add a single object to ps's world */
@@ -321,7 +321,7 @@ TEST_P(CollisionDetectorTests, ClearDiff)
   SCOPED_TRACE(plugin_name);
 
   urdf::ModelInterfaceSharedPtr urdf_model = moveit::core::loadModelInterface("pr2");
-  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  auto srdf_model = std::make_shared<srdf::Model>();
   // create parent scene
   planning_scene::PlanningScenePtr parent = std::make_shared<planning_scene::PlanningScene>(urdf_model, srdf_model);
 

--- a/moveit_core/robot_state/test/test_kinematic_complex.cpp
+++ b/moveit_core/robot_state/test/test_kinematic_complex.cpp
@@ -78,7 +78,7 @@ TEST_F(LoadPlanningModelsPr2, InitOK)
 
 TEST_F(LoadPlanningModelsPr2, ModelInit)
 {
-  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  auto srdf_model = std::make_shared<srdf::Model>();
 
   // with no world multidof we should get a fixed joint
   moveit::core::RobotModel robot_model0(urdf_model_, srdf_model);
@@ -122,7 +122,7 @@ TEST_F(LoadPlanningModelsPr2, GroupInit)
                                      "</group>"
                                      "</robot>";
 
-  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  auto srdf_model = std::make_shared<srdf::Model>();
   srdf_model->initString(*urdf_model_, SMODEL1);
   moveit::core::RobotModel robot_model1(urdf_model_, srdf_model);
 

--- a/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
+++ b/moveit_core/utils/include/moveit/utils/robot_model_test_utils.h
@@ -126,6 +126,13 @@ public:
   RobotModelBuilder& addCollisionMesh(const std::string& link_name, const std::string& filename,
                                       geometry_msgs::Pose origin);
 
+  /** \brief Adds a collision sphere to a specific link.
+   *  \param[in] link_name The name of the link to which the sphere will be added. Must already be in the builder.
+   *  \param[in] radius The radius of the sphere
+   *  \param[in] origin The origin pose of this collision sphere relative to the link origin
+   */
+  RobotModelBuilder& addCollisionSphere(const std::string& link_name, double dims, geometry_msgs::Pose origin);
+
   /** \brief Adds a collision box to a specific link.
    *  \param[in] link_name The name of the link to which the box will be added. Must already be in the builder.
    *  \param[in] dims   The dimensions of the box

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -82,7 +82,7 @@ urdf::ModelInterfaceSharedPtr loadModelInterface(const std::string& robot_name)
 srdf::ModelSharedPtr loadSRDFModel(const std::string& robot_name)
 {
   urdf::ModelInterfaceSharedPtr urdf_model = loadModelInterface(robot_name);
-  srdf::ModelSharedPtr srdf_model(new srdf::Model());
+  auto srdf_model = std::make_shared<srdf::Model>();
   std::string srdf_path;
   if (robot_name == "pr2")
   {
@@ -129,7 +129,7 @@ RobotModelBuilder::RobotModelBuilder(const std::string& name, const std::string&
   urdf_model_->clear();
   urdf_model_->name_ = name;
 
-  urdf::LinkSharedPtr base_link(new urdf::Link);
+  auto base_link = std::make_shared<urdf::Link>();
   base_link->name = base_link_name;
   urdf_model_->links_.insert(std::make_pair(base_link_name, base_link));
 
@@ -174,10 +174,10 @@ RobotModelBuilder& RobotModelBuilder::addChain(const std::string& section, const
       is_valid_ = false;
       return *this;
     }
-    urdf::LinkSharedPtr link(new urdf::Link);
+    auto link = std::make_shared<urdf::Link>();
     link->name = link_names[i];
     urdf_model_->links_.insert(std::make_pair(link_names[i], link));
-    urdf::JointSharedPtr joint(new urdf::Joint);
+    auto joint = std::make_shared<urdf::Joint>();
     joint->name = link_names[i - 1] + "-" + link_names[i] + "-joint";
     // Default to Identity transform for origins.
     joint->parent_to_joint_origin_transform.clear();
@@ -213,7 +213,7 @@ RobotModelBuilder& RobotModelBuilder::addChain(const std::string& section, const
     joint->axis = joint_axis;
     if (joint->type == urdf::Joint::REVOLUTE || joint->type == urdf::Joint::PRISMATIC)
     {
-      urdf::JointLimitsSharedPtr limits(new urdf::JointLimits);
+      auto limits = std::make_shared<urdf::JointLimits>();
       limits->lower = -boost::math::constants::pi<double>();
       limits->upper = boost::math::constants::pi<double>();
 
@@ -235,7 +235,7 @@ RobotModelBuilder& RobotModelBuilder::addInertial(const std::string& link_name, 
     return *this;
   }
 
-  urdf::InertialSharedPtr inertial(new urdf::Inertial);
+  auto inertial = std::make_shared<urdf::Inertial>();
   inertial->origin.position = urdf::Vector3(origin.position.x, origin.position.y, origin.position.z);
   inertial->origin.rotation =
       urdf::Rotation(origin.orientation.x, origin.orientation.y, origin.orientation.z, origin.orientation.w);
@@ -257,8 +257,8 @@ RobotModelBuilder& RobotModelBuilder::addInertial(const std::string& link_name, 
 RobotModelBuilder& RobotModelBuilder::addVisualBox(const std::string& link_name, const std::vector<double>& size,
                                                    geometry_msgs::Pose origin)
 {
-  urdf::VisualSharedPtr vis(new urdf::Visual);
-  urdf::BoxSharedPtr geometry(new urdf::Box);
+  auto vis = std::make_shared<urdf::Visual>();
+  auto geometry = std::make_shared<urdf::Box>();
   geometry->dim = urdf::Vector3(size[0], size[1], size[2]);
   vis->geometry = geometry;
   addLinkVisual(link_name, vis, origin);
@@ -268,8 +268,8 @@ RobotModelBuilder& RobotModelBuilder::addVisualBox(const std::string& link_name,
 RobotModelBuilder& RobotModelBuilder::addCollisionSphere(const std::string& link_name, double radius,
                                                          geometry_msgs::Pose origin)
 {
-  urdf::CollisionSharedPtr coll(new urdf::Collision);
-  urdf::SphereSharedPtr geometry(new urdf::Sphere);
+  auto coll = std::make_shared<urdf::Collision>();
+  auto geometry = std::make_shared<urdf::Sphere>();
   geometry->radius = radius;
   coll->geometry = geometry;
   addLinkCollision(link_name, coll, origin);
@@ -285,8 +285,8 @@ RobotModelBuilder& RobotModelBuilder::addCollisionBox(const std::string& link_na
     is_valid_ = false;
     return *this;
   }
-  urdf::CollisionSharedPtr coll(new urdf::Collision);
-  urdf::BoxSharedPtr geometry(new urdf::Box);
+  auto coll = std::make_shared<urdf::Collision>();
+  auto geometry = std::make_shared<urdf::Box>();
   geometry->dim = urdf::Vector3(dims[0], dims[1], dims[2]);
   coll->geometry = geometry;
   addLinkCollision(link_name, coll, origin);
@@ -296,8 +296,8 @@ RobotModelBuilder& RobotModelBuilder::addCollisionBox(const std::string& link_na
 RobotModelBuilder& RobotModelBuilder::addCollisionMesh(const std::string& link_name, const std::string& filename,
                                                        geometry_msgs::Pose origin)
 {
-  urdf::CollisionSharedPtr coll(new urdf::Collision);
-  urdf::MeshSharedPtr geometry(new urdf::Mesh);
+  auto coll = std::make_shared<urdf::Collision>();
+  auto geometry = std::make_shared<urdf::Mesh>();
   geometry->filename = filename;
   coll->geometry = geometry;
   addLinkCollision(link_name, coll, origin);

--- a/moveit_core/utils/src/robot_model_test_utils.cpp
+++ b/moveit_core/utils/src/robot_model_test_utils.cpp
@@ -265,6 +265,17 @@ RobotModelBuilder& RobotModelBuilder::addVisualBox(const std::string& link_name,
   return *this;
 }
 
+RobotModelBuilder& RobotModelBuilder::addCollisionSphere(const std::string& link_name, double radius,
+                                                         geometry_msgs::Pose origin)
+{
+  urdf::CollisionSharedPtr coll(new urdf::Collision);
+  urdf::SphereSharedPtr geometry(new urdf::Sphere);
+  geometry->radius = radius;
+  coll->geometry = geometry;
+  addLinkCollision(link_name, coll, origin);
+  return *this;
+}
+
 RobotModelBuilder& RobotModelBuilder::addCollisionBox(const std::string& link_name, const std::vector<double>& dims,
                                                       geometry_msgs::Pose origin)
 {

--- a/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
+++ b/moveit_ros/planning/rdf_loader/src/rdf_loader.cpp
@@ -87,7 +87,7 @@ rdf_loader::RDFLoader::RDFLoader(const std::string& robot_description)
     return;
   }
 
-  srdf::ModelSharedPtr srdf(new srdf::Model());
+  auto srdf = std::make_shared<srdf::Model>();
   if (!srdf->initString(*urdf_, scontent))
   {
     ROS_ERROR_NAMED("rdf_loader", "Unable to parse SRDF from parameter '%s'", srdf_description.c_str());

--- a/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
+++ b/moveit_ros/robot_interaction/test/locked_robot_state_test.cpp
@@ -222,7 +222,7 @@ static moveit::core::RobotModelPtr getModel()
   if (!model)
   {
     urdf::ModelInterfaceSharedPtr urdf(urdf::parseURDF(URDF_STR));
-    srdf::ModelSharedPtr srdf(new srdf::Model());
+    auto srdf = std::make_shared<srdf::Model>();
     srdf->initString(*urdf, SRDF_STR);
     model = std::make_shared<moveit::core::RobotModel>(urdf, srdf);
   }


### PR DESCRIPTION
Addresses a rather small inconsistency I pointed out [here](https://github.com/ros-planning/moveit/pull/3504#pullrequestreview-1657191555).

Two more helper patches are included to make the test nicer and the API slightly better.