### PR TITLE
[clang16] do not define unused variables

### DIFF
--- a/moveit_core/collision_detection/src/collision_octomap_filter.cpp
+++ b/moveit_core/collision_detection/src/collision_octomap_filter.cpp
@@ -115,14 +115,14 @@ int collision_detection::refineContactNormals(const World::ObjectConstPtr& objec
               octree->begin_leafs_bbx(bbx_min, bbx_max);
           octomap::OcTreeBaseImpl<octomap::OcTreeNode, octomap::AbstractOccupancyOcTree>::leaf_bbx_iterator leafs_end =
               octree->end_leafs_bbx();
-          int count = 0;
+          // int count = 0;
           for (; it != leafs_end; ++it)
           {
             octomap::point3d pt = it.getCoordinate();
             // double prob = it->getOccupancy();
             if (octree->isNodeOccupied(*it))  // magic number!
             {
-              count++;
+              // count++;
               node_centers.push_back(pt);
               // ROS_INFO_NAMED("collision_detection", "Adding point %d with prob %.3f at [%.3f, %.3f, %.3f]",
               //                          count, prob, pt.x(), pt.y(), pt.z());

--- a/moveit_core/distance_field/test/test_distance_field.cpp
+++ b/moveit_core/distance_field/test/test_distance_field.cpp
@@ -751,14 +751,12 @@ TEST(TestSignedPropagationDistanceField, TestPerformance)
                                     PERF_ORIGIN_Z, PERF_MAX_DIST, true);
 
   EigenSTL::vector_Vector3d bad_vec;
-  unsigned int count = 0;
   for (unsigned int z = UNIFORM_DISTANCE; z < worstdfu.getZNumCells() - UNIFORM_DISTANCE; z += UNIFORM_DISTANCE)
   {
     for (unsigned int x = UNIFORM_DISTANCE; x < worstdfu.getXNumCells() - UNIFORM_DISTANCE; x += UNIFORM_DISTANCE)
     {
       for (unsigned int y = UNIFORM_DISTANCE; y < worstdfu.getYNumCells() - UNIFORM_DISTANCE; y += UNIFORM_DISTANCE)
       {
-        count++;
         Eigen::Vector3d loc;
         bool valid = worstdfu.gridToWorld(x, y, z, loc.x(), loc.y(), loc.z());
 

--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/octomap_render.cpp
@@ -166,7 +166,6 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
 
   unsigned int render_mode_mask = static_cast<unsigned int>(octree_voxel_rendering);
 
-  size_t point_count = 0;
   {
     int step_size = 1 << (octree->getTreeDepth() - octree_depth_);  // for pruning of occluded voxels
 
@@ -249,8 +248,6 @@ void OcTreeRender::octreeDecoding(const std::shared_ptr<const octomap::OcTree>& 
         // push to point vectors
         unsigned int depth = it.getDepth();
         point_buf[depth - 1].push_back(new_point);
-
-        ++point_count;
       }
     }
   }

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -494,7 +494,6 @@ void RobotPosesWidget::loadJointSliders(const QString& selected)
   const auto& robot_state = config_data_->getPlanningScene()->getCurrentState();
 
   // Iterate through the joints
-  int num_joints = 0;
   for (const moveit::core::JointModel* joint_model : joint_model_group->getJointModels())
   {
     if (joint_model->getVariableCount() != 1 ||  // only consider 1-variable joints
@@ -511,8 +510,6 @@ void RobotPosesWidget::loadJointSliders(const QString& selected)
     // Connect value change event
     connect(sw, SIGNAL(jointValueChanged(const std::string&, double)), this,
             SLOT(updateRobotModel(const std::string&, double)));
-
-    ++num_joints;
   }
 
   // Update the robot model in Rviz with newly selected joint values


### PR DESCRIPTION
clang 16 warns about them and builds with Werror fail.
