### PR TITLE
use correct resources branch in ikfast test

### DIFF
--- a/moveit_kinematics/test/test_ikfast_plugins.sh
+++ b/moveit_kinematics/test/test_ikfast_plugins.sh
@@ -20,7 +20,7 @@ else
 fi
 
 # Clone moveit_resources for URDFs. They are not available before running docker.
-git clone -q --depth=1 https://github.com/ros-planning/moveit_resources /tmp/ros/src/moveit_resources
+git clone -q -b master --depth=1 https://github.com/ros-planning/moveit_resources /tmp/ros/src/moveit_resources
 docker run --rm -v /tmp/ros:/tmp/ros -w /tmp/ros "$DOCKER_IMAGE" bash -c "catkin build --no-status --no-summary --no-deps moveit_resources_panda_description"
 
 fanuc=/tmp/ros/src/moveit_resources/fanuc_description/urdf/fanuc.urdf


### PR DESCRIPTION
The default was switched to `ros2` at some point.

Found due to these lines in CI:

```
[build] Found 7 packages in 0.0 seconds.
[build] Updating package table.
[build] Warning: Skipping package `moveit_resources_panda_description` because it has an unsupported package build type: `ament_cmake`
[build] Note: Available build types:
[build]  - `catkin`
[build]  - `cmake`
Starting >>> catkin_tools_prebuild
Finished <<< catkin_tools_prebuild                [ 2.4 seconds ]
[build] Summary: All 1 packages succeeded!
```
