### PR TITLE
Checkbox to display joints in radians

### DIFF
--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
@@ -171,13 +171,24 @@ public:
     JointTypeRole = Qt::UserRole,  // NOLINT(readability-identifier-naming)
     VariableBoundsRole             // NOLINT(readability-identifier-naming)
   };
+  enum RevoluteUnit
+  {
+    Degrees = 0,
+    Radians = 1,
+  };
 
-  ProgressBarDelegate(QWidget* parent = nullptr) : QStyledItemDelegate(parent)
+  ProgressBarDelegate(QWidget* parent = nullptr) : QStyledItemDelegate(parent), unit_(Degrees)
   {
   }
 
+  void setUnit(RevoluteUnit unit)
+  {
+    unit_ = unit;
+  }
   void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
   QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+
+  RevoluteUnit unit_;
 };
 
 /// Slider that jumps back to zero

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
@@ -179,11 +179,11 @@ public:
   };
   enum RevoluteUnit
   {
-    Degrees = 0,
-    Radians = 1,
+    DEGREES = 0,
+    RADIANS = 1,
   };
 
-  ProgressBarDelegate(QWidget* parent = nullptr) : QStyledItemDelegate(parent), unit_(Degrees)
+  ProgressBarDelegate(QWidget* parent = nullptr) : QStyledItemDelegate(parent), unit_(DEGREES)
   {
   }
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/include/moveit/motion_planning_rviz_plugin/motion_planning_frame_joints_widget.h
@@ -134,6 +134,12 @@ public:
                            const robot_interaction::InteractionHandlerPtr& start_state_handler,
                            const robot_interaction::InteractionHandlerPtr& goal_state_handler);
 
+  bool useRadians() const;
+  void setUseRadians(bool use_radians);
+
+Q_SIGNALS:
+  void configChanged();
+
 public Q_SLOTS:
   void queryStartStateChanged();
   void queryGoalStateChanged();

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_display.cpp
@@ -1361,6 +1361,8 @@ void MotionPlanningDisplay::load(const rviz::Config& config)
       frame_->ui_->collision_aware_ik->setChecked(b);
     if (config.mapGetBool("MoveIt_Allow_Approximate_IK", &b))
       frame_->ui_->approximate_ik->setChecked(b);
+    if (config.mapGetBool("JointsTab_Use_Radians", &b))
+      frame_->joints_tab_->setUseRadians(true);
 
     rviz::Config workspace = config.mapGetChild("MoveIt_Workspace");
     rviz::Config ws_center = workspace.mapGetChild("Center");
@@ -1413,6 +1415,7 @@ void MotionPlanningDisplay::save(rviz::Config config) const
     config.mapSetValue("MoveIt_Use_Cartesian_Path", frame_->ui_->use_cartesian_path->isChecked());
     config.mapSetValue("MoveIt_Use_Constraint_Aware_IK", frame_->ui_->collision_aware_ik->isChecked());
     config.mapSetValue("MoveIt_Allow_Approximate_IK", frame_->ui_->approximate_ik->isChecked());
+    config.mapSetValue("JointsTab_Use_Radians", frame_->joints_tab_->useRadians());
 
     rviz::Config workspace = config.mapMakeChild("MoveIt_Workspace");
     rviz::Config ws_center = workspace.mapMakeChild("Center");

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -154,6 +154,8 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
   connect(ui_->database_host, SIGNAL(textChanged(QString)), this, SIGNAL(configChanged()));
   connect(ui_->database_port, SIGNAL(valueChanged(int)), this, SIGNAL(configChanged()));
 
+  connect(joints_tab_, SIGNAL(configChanged()), this, SIGNAL(configChanged()));
+
   connect(ui_->planning_time, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));
   connect(ui_->planning_attempts, SIGNAL(valueChanged(int)), this, SIGNAL(configChanged()));
   connect(ui_->velocity_scaling_factor, SIGNAL(valueChanged(double)), this, SIGNAL(configChanged()));

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame.cpp
@@ -150,7 +150,7 @@ MotionPlanningFrame::MotionPlanningFrame(MotionPlanningDisplay* pdisplay, rviz::
 
   connect(ui_->tabWidget, SIGNAL(currentChanged(int)), this, SLOT(tabChanged(int)));
 
-  /* Notice changes to be safed in config file */
+  /* Notice changes to be saved in config file */
   connect(ui_->database_host, SIGNAL(textChanged(QString)), this, SIGNAL(configChanged()));
   connect(ui_->database_port, SIGNAL(valueChanged(int)), this, SIGNAL(configChanged()));
 

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -196,17 +196,18 @@ MotionPlanningFrameJointsWidget::MotionPlanningFrameJointsWidget(MotionPlanningD
   auto delegate = new ProgressBarDelegate(this);
   ui_->button_group_units_->setId(ui_->radio_degree_, ProgressBarDelegate::Degrees);
   ui_->button_group_units_->setId(ui_->radio_radian_, ProgressBarDelegate::Radians);
-  connect(ui_->button_group_units_, &QButtonGroup::idToggled, ui_->joints_view_, [delegate, this](int id, bool checked) {
-    if (checked)
-    {
-      delegate->setUnit(static_cast<ProgressBarDelegate::RevoluteUnit>(id));
-      // trigger repaint of joint values
-      auto model = ui_->joints_view_->model();
-      if (model)  // during initial loading, the model is not yet set
-        ui_->joints_view_->dataChanged(model->index(0, 1), model->index(model->rowCount() - 1, 1));
-      Q_EMIT configChanged();
-    }
-  });
+  connect(ui_->button_group_units_, QOverload<QAbstractButton*, bool>::of(&QButtonGroup::buttonToggled),
+          ui_->joints_view_, [delegate, this](QAbstractButton* button, bool checked) {
+            if (checked)
+            {
+              delegate->setUnit(static_cast<ProgressBarDelegate::RevoluteUnit>(ui_->button_group_units_->id(button)));
+              // trigger repaint of joint values
+              auto model = ui_->joints_view_->model();
+              if (model)  // during initial loading, the model is not yet set
+                ui_->joints_view_->dataChanged(model->index(0, 1), model->index(model->rowCount() - 1, 1));
+              Q_EMIT configChanged();
+            }
+          });
   ui_->joints_view_->setItemDelegateForColumn(1, delegate);
   svd_.setThreshold(0.001);
 }

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -194,8 +194,8 @@ MotionPlanningFrameJointsWidget::MotionPlanningFrameJointsWidget(MotionPlanningD
   ui_->joints_view_->installEventFilter(new JointsWidgetEventFilter(ui_->joints_view_));
 
   auto delegate = new ProgressBarDelegate(this);
-  ui_->button_group_units_->setId(ui_->radio_degree_, ProgressBarDelegate::Degrees);
-  ui_->button_group_units_->setId(ui_->radio_radian_, ProgressBarDelegate::Radians);
+  ui_->button_group_units_->setId(ui_->radio_degree_, ProgressBarDelegate::DEGREES);
+  ui_->button_group_units_->setId(ui_->radio_radian_, ProgressBarDelegate::RADIANS);
   connect(ui_->button_group_units_, QOverload<QAbstractButton*, bool>::of(&QButtonGroup::buttonToggled),
           ui_->joints_view_, [delegate, this](QAbstractButton* button, bool checked) {
             if (checked)
@@ -442,7 +442,7 @@ void ProgressBarDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
       switch (joint_type.toInt())
       {
         case moveit::core::JointModel::REVOLUTE:
-          if (unit_ == Radians)
+          if (unit_ == RADIANS)
             style_option.text = option.locale.toString(value, 'f', 3);
           else
             style_option.text = option.locale.toString(value * 180 / M_PI, 'f', 0).append("°");

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -192,10 +192,18 @@ MotionPlanningFrameJointsWidget::MotionPlanningFrameJointsWidget(MotionPlanningD
   ui_->joints_view_->viewport()->installEventFilter(new JointsWidgetEventFilter(ui_->joints_view_));
   // intercept keyboard events delivered to joints_view_ to operate joints directly
   ui_->joints_view_->installEventFilter(new JointsWidgetEventFilter(ui_->joints_view_));
+
   auto delegate = new ProgressBarDelegate(this);
-  connect(ui_->button_group_units_, static_cast<void(QButtonGroup::*)(int, bool)>(&QButtonGroup::buttonToggled), [delegate](int id, bool checked) {
+  ui_->button_group_units_->setId(ui_->radio_degree_, ProgressBarDelegate::Degrees);
+  ui_->button_group_units_->setId(ui_->radio_radian_, ProgressBarDelegate::Radians);
+  connect(ui_->button_group_units_, &QButtonGroup::idToggled, ui_->joints_view_, [delegate, this](int id, bool checked) {
     if (checked)
-      delegate->setUnit(id == 0 ? ProgressBarDelegate::Degrees : ProgressBarDelegate::Radians);
+    {
+      delegate->setUnit(static_cast<ProgressBarDelegate::RevoluteUnit>(id));
+      // trigger repaint of joint values
+      auto model = ui_->joints_view_->model();
+      ui_->joints_view_->dataChanged(model->index(0, 1), model->index(model->rowCount() - 1, 1));
+    }
   });
   ui_->joints_view_->setItemDelegateForColumn(1, delegate);
   svd_.setThreshold(0.001);

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -192,7 +192,12 @@ MotionPlanningFrameJointsWidget::MotionPlanningFrameJointsWidget(MotionPlanningD
   ui_->joints_view_->viewport()->installEventFilter(new JointsWidgetEventFilter(ui_->joints_view_));
   // intercept keyboard events delivered to joints_view_ to operate joints directly
   ui_->joints_view_->installEventFilter(new JointsWidgetEventFilter(ui_->joints_view_));
-  ui_->joints_view_->setItemDelegateForColumn(1, new ProgressBarDelegate(this));
+  auto delegate = new ProgressBarDelegate(this);
+  connect(ui_->joints_view_->button_group_units_, QButtonGroup::idToggled, [delegate](int id, bool checked) {
+    if (checked)
+      delegate->setUnit(id == 0 ? ProgressBarDelegate::Degrees : ProgressBarDelegate::Radians);
+  });
+  ui_->joints_view_->setItemDelegateForColumn(1, delegate);
   svd_.setThreshold(0.001);
 }
 
@@ -417,8 +422,8 @@ void ProgressBarDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
       switch (joint_type.toInt())
       {
         case moveit::core::JointModel::REVOLUTE:
-          if (false) //TODO: FLAG connect to the checkbox update
-            style_option.text = option.locale.toString(value, 'f', 3).append(" rad");
+          if (unit_ == Radians)
+            style_option.text = option.locale.toString(value, 'f', 3);
           else
             style_option.text = option.locale.toString(value * 180 / M_PI, 'f', 0).append("°");
           break;

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -193,7 +193,7 @@ MotionPlanningFrameJointsWidget::MotionPlanningFrameJointsWidget(MotionPlanningD
   // intercept keyboard events delivered to joints_view_ to operate joints directly
   ui_->joints_view_->installEventFilter(new JointsWidgetEventFilter(ui_->joints_view_));
   auto delegate = new ProgressBarDelegate(this);
-  connect(ui_->joints_view_->button_group_units_, QButtonGroup::idToggled, [delegate](int id, bool checked) {
+  connect(ui_->button_group_units_, static_cast<void(QButtonGroup::*)(int, bool)>(&QButtonGroup::buttonToggled), [delegate](int id, bool checked) {
     if (checked)
       delegate->setUnit(id == 0 ? ProgressBarDelegate::Degrees : ProgressBarDelegate::Radians);
   });

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -202,7 +202,9 @@ MotionPlanningFrameJointsWidget::MotionPlanningFrameJointsWidget(MotionPlanningD
       delegate->setUnit(static_cast<ProgressBarDelegate::RevoluteUnit>(id));
       // trigger repaint of joint values
       auto model = ui_->joints_view_->model();
-      ui_->joints_view_->dataChanged(model->index(0, 1), model->index(model->rowCount() - 1, 1));
+      if (model)  // during initial loading, the model is not yet set
+        ui_->joints_view_->dataChanged(model->index(0, 1), model->index(model->rowCount() - 1, 1));
+      Q_EMIT configChanged();
     }
   });
   ui_->joints_view_->setItemDelegateForColumn(1, delegate);
@@ -212,6 +214,15 @@ MotionPlanningFrameJointsWidget::MotionPlanningFrameJointsWidget(MotionPlanningD
 MotionPlanningFrameJointsWidget::~MotionPlanningFrameJointsWidget()
 {
   delete ui_;
+}
+
+bool MotionPlanningFrameJointsWidget::useRadians() const
+{
+  return ui_->radio_radian_->isChecked();
+}
+void MotionPlanningFrameJointsWidget::setUseRadians(bool use_radians)
+{
+  ui_->radio_radian_->setChecked(use_radians);
 }
 
 void MotionPlanningFrameJointsWidget::clearRobotModel()

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/motion_planning_frame_joints_widget.cpp
@@ -417,7 +417,10 @@ void ProgressBarDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
       switch (joint_type.toInt())
       {
         case moveit::core::JointModel::REVOLUTE:
-          style_option.text = option.locale.toString(value * 180 / M_PI, 'f', 0).append("°");
+          if (false) //TODO: FLAG connect to the checkbox update
+            style_option.text = option.locale.toString(value, 'f', 3).append(" rad");
+          else
+            style_option.text = option.locale.toString(value * 180 / M_PI, 'f', 0).append("°");
           break;
         case moveit::core::JointModel::PRISMATIC:
           style_option.text = option.locale.toString(value, 'f', 3).append("m");

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame_joints.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame_joints.ui
@@ -43,6 +43,34 @@
       </widget>
      </item>
      <item>
+      <widget class="QCheckBox" name="display_joints_radians">
+       <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+         </sizepolicy>
+       </property>
+       <property name="minimumSize">
+         <size>
+           <width>30</width>
+           <height>0</height>
+         </size>
+       </property>
+       <property name="toolTip">
+        <string>Check this to change the above joint angle from degrees to radians</string>
+       </property>
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Display joints in Radians</string>
+       </property>
+       <property name="tristate">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="nullspace_label">
        <property name="toolTip">
         <string>The sliders below allow for jogging the nullspace of the current configuration,

--- a/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame_joints.ui
+++ b/moveit_ros/visualization/motion_planning_rviz_plugin/src/ui/motion_planning_rviz_plugin_frame_joints.ui
@@ -13,9 +13,9 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="joints_layout_">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="joints_view_label_">
        <property name="text">
@@ -24,91 +24,99 @@
       </widget>
      </item>
      <item>
-      <widget class="QTreeView" name="joints_view_">
-       <property name="editTriggers">
-        <set>QAbstractItemView::EditKeyPressed</set>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
-       <property name="selectionMode">
-        <enum>QAbstractItemView::NoSelection</enum>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
        </property>
-       <property name="rootIsDecorated">
-        <bool>false</bool>
-       </property>
-       <property name="itemsExpandable">
-        <bool>false</bool>
-       </property>
-       <property name="expandsOnDoubleClick">
-        <bool>false</bool>
-       </property>
-      </widget>
+      </spacer>
      </item>
      <item>
-      <widget class="QCheckBox" name="display_joints_radians">
-       <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-         </sizepolicy>
+      <widget class="QRadioButton" name="radio_degree_">
+       <property name="text">
+        <string>degree</string>
        </property>
-       <property name="minimumSize">
-         <size>
-           <width>30</width>
-           <height>0</height>
-         </size>
-       </property>
-       <property name="toolTip">
-        <string>Check this to change the above joint angle from degrees to radians</string>
-       </property>
-       <property name="enabled">
+       <property name="checked">
         <bool>true</bool>
        </property>
-       <property name="text">
-        <string>Display joints in Radians</string>
-       </property>
-       <property name="tristate">
-        <bool>false</bool>
-       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">button_group_units_</string>
+       </attribute>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="nullspace_label">
-       <property name="toolTip">
-        <string>The sliders below allow for jogging the nullspace of the current configuration,
+      <widget class="QRadioButton" name="radio_radian_">
+       <property name="text">
+        <string>radian</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">button_group_units_</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTreeView" name="joints_view_">
+     <property name="editTriggers">
+      <set>QAbstractItemView::EditKeyPressed</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="rootIsDecorated">
+      <bool>false</bool>
+     </property>
+     <property name="itemsExpandable">
+      <bool>false</bool>
+     </property>
+     <property name="expandsOnDoubleClick">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="nullspace_label">
+     <property name="toolTip">
+      <string>The sliders below allow for jogging the nullspace of the current configuration,
 i.e. trigger joint motions that don't affect the end-effector pose.
 
 Typically, redundant arms (with 7+ joints) offer such a nullspace.
 However, also singular configurations provide a nullspace.
 
 Each basis vector of the (linear) nullspace is represented by a separate slider.</string>
+     </property>
+     <property name="text">
+      <string>Nullspace exploration:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="nullspace_layout_">
+     <item>
+      <widget class="QSlider" name="dummy_ns_slider_">
+       <property name="enabled">
+        <bool>false</bool>
        </property>
-       <property name="text">
-        <string>Nullspace exploration:</string>
+       <property name="toolTip">
+        <string>The slider will become active if the current robot configuration has a nullspace.
+That's typically the case for redundant robots, i.e. 7+ joints, or singular configurations.</string>
+       </property>
+       <property name="minimum">
+        <number>-1</number>
+       </property>
+       <property name="maximum">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
       </widget>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="nullspace_layout_">
-       <item>
-        <widget class="QSlider" name="dummy_ns_slider_">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="toolTip">
-          <string>The slider will become active if the current robot configuration has a nullspace.
-That's typically the case for redundant robots, i.e. 7+ joints, or singular configurations.</string>
-         </property>
-         <property name="minimum">
-          <number>-1</number>
-         </property>
-         <property name="maximum">
-          <number>1</number>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
      </item>
     </layout>
    </item>
@@ -116,4 +124,7 @@ That's typically the case for redundant robots, i.e. 7+ joints, or singular conf
  </widget>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="button_group_units_"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
### Description

Issue #3513 Add a checkbox to display joints in radians
Need help to connect it to the flag.

![image](https://github.com/ros-planning/moveit/assets/44398228/6554c88b-a106-4882-9629-e4abe4164f02)
![image](https://github.com/ros-planning/moveit/assets/44398228/4859b11b-4143-45a6-9f2e-46323547f885)


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
