### PR TITLE
Adds a MeshCache to _msgsToAttachedBody to prevent duplicate attached collision objects being stored in FCLShapeCache

### DIFF
--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -43,4 +43,7 @@ if(CATKIN_ENABLE_TESTING)
 
   catkin_add_gtest(test_aabb test/test_aabb.cpp)
   target_link_libraries(test_aabb ${MOVEIT_LIB_NAME} moveit_test_utils)
+
+  catkin_add_gtest(test_mesh_cache test/test_mesh_cache.cpp)
+  target_link_libraries(test_mesh_cache ${MOVEIT_LIB_NAME} moveit_test_utils)
 endif()

--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MOVEIT_LIB_NAME moveit_robot_state)
 
 add_library(${MOVEIT_LIB_NAME}
   src/attached_body.cpp
+  src/mesh_cache.cpp
   src/conversions.cpp
   src/robot_state.cpp
   src/cartesian_interpolator.cpp

--- a/moveit_core/robot_state/include/moveit/robot_state/mesh_cache.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/mesh_cache.h
@@ -41,43 +41,81 @@ namespace moveit
 {
 namespace core
 {
+
+/// \brief The type used to hash meshes.
 using MeshHash = std::size_t;
+
+/// \brief The type used to hash times.
 using TimeHash = std::pair<int, int>;
 
+/// \brief Convert a shape_msgs::mesh to a std::string.
 std::string meshString(const shape_msgs::Mesh& mesh);
 
+/// \brief Convert a std::string to a MeshHash.
 MeshHash hashMeshString(const std::string& mesh_string);
 
+/// \brief Convert a shape_msgs::Mesh to a MeshHash.
 MeshHash hashMesh(const shape_msgs::Mesh& mesh);
 
+/// \brief Convert a ros::Time to a TimeHash.
 TimeHash hashTime(const ros::Time& time);
 
+/** \brief Control block used to store a shapes::ShapeConstPtr, and related metadata.
+
+    The metadata allows for exact comparisons with shape_msgs::Mesh types,
+    and for tracking the relative usage times of meshes.*/
 struct MeshCacheControlBlock
 {
+  /// \brief The input shape_msgs::Mesh as a std::string.
   std::string mesh_string_;
+  /// \brief The hash of `mesh_string_`.
   MeshHash mesh_hash_;
+  /// \brief The cached shape.
   shapes::ShapeConstPtr shape_;
+  /// \brief The last time this shape was used.
   ros::Time last_used_;
+  /// \brief The hash of `last_used_`.
   TimeHash last_used_hash_;
+  /// \brief The approximate memory use of this control block.
   std::size_t approximateMemoryUse() const;
 };
 
+/** \brief A cache of shapes::ShapeConstPtr shapes, constructed from shape_msgs::Mesh.
+
+    This cache is designed to allow shapes to be aliased, rather than being regenerated.
+    Automatically evicts members to maintain an (approximate) maximum memory usage.
+    Uses a least-recently-used cache eviction policy.*/
 class MeshCache
 {
 public:
+  /** \brief Cache constructor
+      \param min_size_to_cache The minimum size of a shape_msgs::Mesh to cache.
+      \param max_cache_size The (approximate) maximum memory usage of the cache.*/
   MeshCache(std::size_t min_size_to_cache = 0, std::size_t max_cache_size = std::numeric_limits<std::size_t>::max());
-  static MeshCache& threadLocalCache();
+  /** \brief Returns a reference to a thread-local static MeshCache. */
+  static MeshCache& threadLocalCache(std::size_t min_size_to_cache = 0,
+                                     std::size_t max_cache_size = std::numeric_limits<std::size_t>::max());
+  /** \brief Returns the shapes::ShapeConstrPtr corresponding to `mesh`.
+
+      The returned shape will come from the cache if present.
+      The generated shape will be added to the cache if it is not present.*/
   shapes::ShapeConstPtr getShape(const shape_msgs::Mesh& mesh);
 
 private:
+  /** \brief Adds `control_block` to the cache.*/
   void cacheControlBlock(std::shared_ptr<MeshCacheControlBlock> control_block);
+  /** \brief Removes `control_block` from the cache.*/
   void removeControlBlock(std::shared_ptr<MeshCacheControlBlock> control_block);
+  /** \brief Updates the last used timestamp of `control_block` to now.*/
   void updateLastUsed(std::shared_ptr<MeshCacheControlBlock> control_block);
 
   const std::size_t min_size_to_cache_;
   const std::size_t max_cache_size_;
+  /** \brief Control blocks stored by mesh hash, for mesh lookup.*/
   std::map<MeshHash, std::shared_ptr<MeshCacheControlBlock>> cache_by_mesh_hash_;
+  /** \brief Control blocks stored by timestamp, for cache eviction.*/
   std::map<TimeHash, std::shared_ptr<MeshCacheControlBlock>> cache_by_last_used_;
+  /** \brief The current (approximate) memory usage of the cache.*/
   std::size_t cache_size_;
 };
 }  // namespace core

--- a/moveit_core/robot_state/include/moveit/robot_state/mesh_cache.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/mesh_cache.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2011, Willow Garage, Inc.
+ *  Copyright (c) 2023, Rivelin Robotics, Ltd.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
+ *   * Neither the name of Rivelin Robotics nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_core/robot_state/include/moveit/robot_state/mesh_cache.h
+++ b/moveit_core/robot_state/include/moveit/robot_state/mesh_cache.h
@@ -1,0 +1,84 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#pragma once
+
+#include <shape_msgs/Mesh.h>
+#include <geometric_shapes/shape_operations.h>
+
+namespace moveit
+{
+namespace core
+{
+using MeshHash = std::size_t;
+using TimeHash = std::pair<int, int>;
+
+std::string meshString(const shape_msgs::Mesh& mesh);
+
+MeshHash hashMeshString(const std::string& mesh_string);
+
+MeshHash hashMesh(const shape_msgs::Mesh& mesh);
+
+TimeHash hashTime(const ros::Time& time);
+
+struct MeshCacheControlBlock
+{
+  std::string mesh_string_;
+  MeshHash mesh_hash_;
+  shapes::ShapeConstPtr shape_;
+  ros::Time last_used_;
+  TimeHash last_used_hash_;
+  std::size_t approximateMemoryUse() const;
+};
+
+class MeshCache
+{
+public:
+  MeshCache(std::size_t min_size_to_cache = 0, std::size_t max_cache_size = std::numeric_limits<std::size_t>::max());
+  static MeshCache& threadLocalCache();
+  shapes::ShapeConstPtr getShape(const shape_msgs::Mesh& mesh);
+
+private:
+  void cacheControlBlock(std::shared_ptr<MeshCacheControlBlock> control_block);
+  void removeControlBlock(std::shared_ptr<MeshCacheControlBlock> control_block);
+  void updateLastUsed(std::shared_ptr<MeshCacheControlBlock> control_block);
+
+  const std::size_t min_size_to_cache_;
+  const std::size_t max_cache_size_;
+  std::map<MeshHash, std::shared_ptr<MeshCacheControlBlock>> cache_by_mesh_hash_;
+  std::map<TimeHash, std::shared_ptr<MeshCacheControlBlock>> cache_by_last_used_;
+  std::size_t cache_size_;
+};
+}  // namespace core
+}  // namespace moveit

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -286,7 +286,7 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
           append(shapes::ShapeConstPtr(shapes::constructShapeFromMsg(aco.object.primitives[i])),
                  aco.object.primitive_poses[i]);
         for (std::size_t i = 0; i < aco.object.meshes.size(); ++i)
-          append(MeshCache::threadLocalCache().getShape(aco.object.meshes[i]), aco.object.mesh_poses[i]);
+          append(MeshCache::threadLocalCache(1e6, 1e9).getShape(aco.object.meshes[i]), aco.object.mesh_poses[i]);
         for (std::size_t i = 0; i < aco.object.planes.size(); ++i)
           append(shapes::ShapeConstPtr(shapes::constructShapeFromMsg(aco.object.planes[i])), aco.object.plane_poses[i]);
 

--- a/moveit_core/robot_state/src/conversions.cpp
+++ b/moveit_core/robot_state/src/conversions.cpp
@@ -36,6 +36,7 @@
 /* Author: Ioan Sucan, Dave Coleman */
 
 #include <moveit/robot_state/conversions.h>
+#include <moveit/robot_state/mesh_cache.h>
 #include <geometric_shapes/shape_operations.h>
 #include <tf2_eigen/tf2_eigen.h>
 #include <boost/lexical_cast.hpp>
@@ -272,21 +273,22 @@ static void _msgToAttachedBody(const Transforms* tf, const moveit_msgs::Attached
         shapes.reserve(num_shapes);
         shape_poses.reserve(num_shapes);
 
-        auto append = [&shapes, &shape_poses](shapes::Shape* s, const geometry_msgs::Pose& pose_msg) {
+        auto append = [&shapes, &shape_poses](shapes::ShapeConstPtr s, const geometry_msgs::Pose& pose_msg) {
           if (!s)
             return;
           Eigen::Isometry3d pose;
           tf2::fromMsg(pose_msg, pose);
-          shapes.emplace_back(shapes::ShapeConstPtr(s));
+          shapes.emplace_back(s);
           shape_poses.emplace_back(std::move(pose));
         };
 
         for (std::size_t i = 0; i < aco.object.primitives.size(); ++i)
-          append(shapes::constructShapeFromMsg(aco.object.primitives[i]), aco.object.primitive_poses[i]);
+          append(shapes::ShapeConstPtr(shapes::constructShapeFromMsg(aco.object.primitives[i])),
+                 aco.object.primitive_poses[i]);
         for (std::size_t i = 0; i < aco.object.meshes.size(); ++i)
-          append(shapes::constructShapeFromMsg(aco.object.meshes[i]), aco.object.mesh_poses[i]);
+          append(MeshCache::threadLocalCache().getShape(aco.object.meshes[i]), aco.object.mesh_poses[i]);
         for (std::size_t i = 0; i < aco.object.planes.size(); ++i)
-          append(shapes::constructShapeFromMsg(aco.object.planes[i]), aco.object.plane_poses[i]);
+          append(shapes::ShapeConstPtr(shapes::constructShapeFromMsg(aco.object.planes[i])), aco.object.plane_poses[i]);
 
         moveit::core::FixedTransformsMap subframe_poses;
         for (std::size_t i = 0; i < aco.object.subframe_poses.size(); ++i)

--- a/moveit_core/robot_state/src/mesh_cache.cpp
+++ b/moveit_core/robot_state/src/mesh_cache.cpp
@@ -1,7 +1,7 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2011, Willow Garage, Inc.
+ *  Copyright (c) 2023, Rivelin Robotics, Ltd.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of the Willow Garage nor the names of its
+ *   * Neither the name of Rivelin Robotics nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *

--- a/moveit_core/robot_state/src/mesh_cache.cpp
+++ b/moveit_core/robot_state/src/mesh_cache.cpp
@@ -1,0 +1,142 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2011, Willow Garage, Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <moveit/robot_state/mesh_cache.h>
+
+namespace moveit
+{
+namespace core
+{
+
+std::string meshString(const shape_msgs::Mesh& mesh)
+{
+  std::ostringstream oss;
+  oss << mesh;
+  return oss.str();
+}
+
+MeshHash hashMeshString(const std::string& mesh_string)
+{
+  return std::hash<std::string>()(mesh_string);
+}
+
+MeshHash hashMesh(const shape_msgs::Mesh& mesh)
+{
+  return hashMeshString(meshString(mesh));
+}
+
+TimeHash hashTime(const ros::Time& time)
+{
+  return std::make_pair(time.sec, time.nsec);
+}
+
+std::size_t MeshCacheControlBlock::approximateMemoryUse() const
+{
+  return sizeof(mesh_string_) + sizeof(*shape_);
+}
+
+MeshCache::MeshCache(std::size_t min_size_to_cache, std::size_t max_cache_size)
+  : min_size_to_cache_(min_size_to_cache), max_cache_size_(max_cache_size), cache_size_(0)
+{
+}
+
+MeshCache& MeshCache::threadLocalCache()
+{
+  static thread_local MeshCache cache(1e6, 1e9);
+  return cache;
+}
+
+shapes::ShapeConstPtr MeshCache::getShape(const shape_msgs::Mesh& mesh)
+{
+  std::string mesh_string = meshString(mesh);
+  MeshHash mesh_hash = hashMeshString(mesh_string);
+
+  auto it = cache_by_mesh_hash_.find(mesh_hash);
+  if (it != cache_by_mesh_hash_.end() and it->second->mesh_string_ == mesh_string)
+  {
+    auto control_block = it->second;
+    updateLastUsed(control_block);
+    return control_block->shape_;
+  }
+  else
+  {
+    shapes::ShapeConstPtr shape(shapes::constructShapeFromMsg(mesh));
+    ros::Time last_used = ros::Time::now();
+    TimeHash last_used_hash = hashTime(last_used);
+    auto control_block = std::make_shared<MeshCacheControlBlock>(
+        MeshCacheControlBlock{ mesh_string, mesh_hash, shape, last_used, last_used_hash });
+    cacheControlBlock(control_block);
+    return shape;
+  }
+}
+
+void MeshCache::cacheControlBlock(std::shared_ptr<MeshCacheControlBlock> control_block)
+{
+  if (control_block->approximateMemoryUse() < min_size_to_cache_)
+  {
+    return;
+  }
+  if (cache_by_mesh_hash_.count(control_block->mesh_hash_) > 0)
+  {
+    removeControlBlock(cache_by_mesh_hash_[control_block->mesh_hash_]);
+  }
+  if (cache_by_last_used_.count(control_block->last_used_hash_) > 0)
+  {
+    removeControlBlock(cache_by_last_used_[control_block->last_used_hash_]);
+  }
+  cache_size_ += control_block->approximateMemoryUse();
+  while (cache_size_ > max_cache_size_)
+  {
+    removeControlBlock(cache_by_last_used_.begin()->second);
+  }
+  cache_by_mesh_hash_[control_block->mesh_hash_] = control_block;
+  cache_by_last_used_[control_block->last_used_hash_] = control_block;
+}
+
+void MeshCache::removeControlBlock(std::shared_ptr<MeshCacheControlBlock> control_block)
+{
+  cache_by_mesh_hash_.erase(control_block->mesh_hash_);
+  cache_by_last_used_.erase(control_block->last_used_hash_);
+  cache_size_ -= control_block->approximateMemoryUse();
+}
+
+void MeshCache::updateLastUsed(std::shared_ptr<MeshCacheControlBlock> control_block)
+{
+  cache_by_last_used_.erase(hashTime(control_block->last_used_));
+  control_block->last_used_ = ros::Time::now();
+  cache_by_last_used_[hashTime(control_block->last_used_)] = control_block;
+}
+
+}  // namespace core
+}  // namespace moveit

--- a/moveit_core/robot_state/test/test_mesh_cache.cpp
+++ b/moveit_core/robot_state/test/test_mesh_cache.cpp
@@ -1,0 +1,177 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, Rivelin Robotics, Ltd.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Rivelin Robotics nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+#include <moveit/robot_state/mesh_cache.h>
+#include <gtest/gtest.h>
+
+namespace moveit
+{
+namespace core
+{
+
+static void expect_near(const shapes::Shape* shape, const shapes::Shape* expected,
+                        double tolerance = std::numeric_limits<double>::epsilon())
+{
+  auto shape_mesh = dynamic_cast<const shapes::Mesh*>(shape);
+  auto expected_mesh = dynamic_cast<const shapes::Mesh*>(expected);
+  ASSERT_EQ((bool)shape_mesh, (bool)expected_mesh);
+  if (expected_mesh)
+  {
+    ASSERT_EQ(shape_mesh->triangle_count, expected_mesh->triangle_count);
+    for (unsigned i = 0; i < 3 * expected_mesh->triangle_count; ++i)
+    {
+      EXPECT_EQ(shape_mesh->triangles[i], expected_mesh->triangles[i]);
+      EXPECT_NEAR(shape_mesh->triangle_normals[i], expected_mesh->triangle_normals[i], tolerance);
+    }
+    ASSERT_EQ(shape_mesh->vertex_count, expected_mesh->vertex_count);
+    for (unsigned i = 0; i < 3 * expected_mesh->vertex_count; ++i)
+    {
+      EXPECT_NEAR(shape_mesh->vertices[i], expected_mesh->vertices[i], tolerance);
+      EXPECT_NEAR(shape_mesh->vertex_normals[i], expected_mesh->vertex_normals[i], tolerance);
+    }
+  }
+}
+
+class MeshCacheTest : public ::testing::Test
+{
+public:
+  MeshCacheTest()
+  {
+    // Generate some points for constructing meshes.
+    geometry_msgs::Point origin;
+    geometry_msgs::Point x;
+    x.x = 1;
+    geometry_msgs::Point y;
+    y.y = 1;
+    geometry_msgs::Point z;
+    z.z = 1;
+
+    // Generate some triangles for constructing meshes.
+    shape_msgs::MeshTriangle triangle_a;
+    triangle_a.vertex_indices = { 0, 1, 2 };
+    shape_msgs::MeshTriangle triangle_b;
+    triangle_b.vertex_indices = { 0, 2, 3 };
+    shape_msgs::MeshTriangle triangle_c;
+    triangle_c.vertex_indices = { 0, 3, 1 };
+
+    // Generate some meshes for testing.
+    single_triangle_mesh_.vertices = { origin, x, y };
+    single_triangle_mesh_.triangles = { triangle_a };
+    multi_triangle_mesh_a_.vertices = { origin, x, y, z };
+    multi_triangle_mesh_a_.triangles = { triangle_a, triangle_b, triangle_c };
+    multi_triangle_mesh_b_.vertices = { x, origin, z, y };
+    multi_triangle_mesh_b_.triangles = { triangle_c, triangle_a, triangle_b };
+  }
+  shape_msgs::Mesh empty_mesh_;
+  shape_msgs::Mesh single_triangle_mesh_;
+  shape_msgs::Mesh multi_triangle_mesh_a_;
+  shape_msgs::Mesh multi_triangle_mesh_b_;
+};
+
+TEST_F(MeshCacheTest, returnsCorrectShapeFromEmptyMesh)
+{
+  MeshCache cache;
+  expect_near(cache.getShape(empty_mesh_).get(), shapes::constructShapeFromMsg(empty_mesh_));
+}
+
+TEST_F(MeshCacheTest, returnsCorrectShapeFromNonEmptyMesh)
+{
+  MeshCache cache;
+  expect_near(cache.getShape(single_triangle_mesh_).get(), shapes::constructShapeFromMsg(single_triangle_mesh_));
+}
+
+TEST_F(MeshCacheTest, aliasesDuplicateMeshes)
+{
+  MeshCache cache;
+  auto shape_a = cache.getShape(single_triangle_mesh_);
+  auto shape_b = cache.getShape(single_triangle_mesh_);
+  EXPECT_EQ(shape_a, shape_b);
+}
+
+TEST_F(MeshCacheTest, doesNotAliasNonDuplicateMeshes)
+{
+  MeshCache cache;
+  auto shape_a = cache.getShape(single_triangle_mesh_);
+  auto shape_b = cache.getShape(multi_triangle_mesh_a_);
+  EXPECT_NE(shape_a, shape_b);
+}
+
+TEST_F(MeshCacheTest, doesNotCacheMeshesSmallerThanMinSize)
+{
+  MeshCache cache(1e3);
+  auto shape_a = cache.getShape(single_triangle_mesh_);
+  auto shape_b = cache.getShape(single_triangle_mesh_);
+  EXPECT_NE(shape_a, shape_b);
+}
+
+TEST_F(MeshCacheTest, doesNotCacheMeshesLargerThanMaxSize)
+{
+  MeshCache cache(0, 0);
+  auto shape_a = cache.getShape(single_triangle_mesh_);
+  auto shape_b = cache.getShape(single_triangle_mesh_);
+  EXPECT_NE(shape_a, shape_b);
+}
+
+TEST_F(MeshCacheTest, expellsOldestAddedMeshWhenCacheFull)
+{
+  MeshCache cache(0, 2500);
+  auto shape_a = cache.getShape(single_triangle_mesh_);
+  auto shape_b = cache.getShape(multi_triangle_mesh_a_);
+  auto shape_c = cache.getShape(multi_triangle_mesh_b_);
+  EXPECT_EQ(cache.getShape(multi_triangle_mesh_a_), shape_b);
+  EXPECT_EQ(cache.getShape(multi_triangle_mesh_b_), shape_c);
+  EXPECT_NE(cache.getShape(single_triangle_mesh_), shape_a);
+}
+
+TEST_F(MeshCacheTest, expellsOldestUsedMeshWhenCacheFull)
+{
+  MeshCache cache(0, 2500);
+  auto shape_a = cache.getShape(multi_triangle_mesh_a_);
+  auto shape_b = cache.getShape(single_triangle_mesh_);
+  auto shape_c = cache.getShape(multi_triangle_mesh_a_);
+  auto shape_d = cache.getShape(multi_triangle_mesh_b_);
+  EXPECT_EQ(cache.getShape(multi_triangle_mesh_a_), shape_a);
+  EXPECT_EQ(cache.getShape(multi_triangle_mesh_b_), shape_d);
+  EXPECT_NE(cache.getShape(single_triangle_mesh_), shape_b);
+}
+
+}  // namespace core
+}  // namespace moveit
+
+int main(int argc, char** argv)
+{
+  ros::Time::init();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### Description

Fixes https://github.com/ros-planning/moveit/issues/3515

Previously, when planning a sequence motion, the attached collision objects would be converted to separate shapes::Mesh* for each waypoint along the path. Then each instance would be come a separate fcl::BVHModel instance in the FCLShapeCache, leading to large computational costs and memory usage when using large attached collision objects.

This PR adds caching of shapes constructed from meshes to _msgsToAttachedBody in conversions.cpp. This means that the shapes::Mesh* pointers passed into the FCLShapeCache are correctly aliased, and fcl::BVHModels do not need to be regenerated.

The mesh cache has an (approximate) maximum memory usage, and evicts cache entries using a last-used-first-out strategy when this memory usage is exceeded.

### Checklist
- [✓] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/) N/A (I think?)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes N/A (no API changes)
- [✓] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI N/A (no GUI changes)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
