### PR TITLE
Tranform Pilz goal pose and center point wrt. the planning frame

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -143,7 +143,10 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
     {
       frame_id = req.goal_constraints.front().position_constraints.front().header.frame_id;
     }
-    info.goal_pose = getConstraintPose(req.goal_constraints.front());
+
+    // goal pose with optional offset wrt. the planning frame
+    info.goal_pose = scene->getFrameTransform(frame_id) * getConstraintPose(req.goal_constraints.front());
+    frame_id = robot_model_->getModelFrame();
 
     // check goal pose ik before Cartesian motion plan start
     std::map<std::string, double> ik_solution;

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -92,7 +92,6 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
   ROS_DEBUG("Extract necessary information from motion plan request.");
 
   info.group_name = req.group_name;
-  std::string frame_id{ robot_model_->getModelFrame() };
   robot_state::RobotState robot_state = scene->getCurrentState();
 
   // goal given in joint space
@@ -131,6 +130,8 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
   // goal given in Cartesian space
   else
   {
+    std::string frame_id;
+
     info.link_name = req.goal_constraints.front().position_constraints.front().link_name;
     if (req.goal_constraints.front().position_constraints.front().header.frame_id.empty() ||
         req.goal_constraints.front().orientation_constraints.front().header.frame_id.empty())

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -160,22 +160,39 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
   }
   computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose);
 
+  // center point with wrt. the planning frame
+  std::string center_point_frame_id;
+
   info.circ_path_point.first = req.path_constraints.name;
-  if (!req.goal_constraints.front().position_constraints.empty())
+  if (req.path_constraints.position_constraints.front().header.frame_id.empty())
   {
-    const moveit_msgs::Constraints& goal = req.goal_constraints.front();
-    info.circ_path_point.second =
-        getConstraintPose(
-            req.path_constraints.position_constraints.front().constraint_region.primitive_poses.front().position,
-            goal.orientation_constraints.front().orientation, goal.position_constraints.front().target_point_offset)
-            .translation();
+    ROS_WARN("Frame id is not set in position constraints of "
+             "path. Use model frame as default");
+    center_point_frame_id = robot_model_->getModelFrame();
   }
   else
   {
-    Eigen::Vector3d circ_path_point;
-    tf2::fromMsg(req.path_constraints.position_constraints.front().constraint_region.primitive_poses.front().position,
-                 circ_path_point);
-    info.circ_path_point.second = circ_path_point;
+    center_point_frame_id = req.path_constraints.position_constraints.front().header.frame_id;
+  }
+
+  Eigen::Isometry3d center_point_pose;
+  tf2::fromMsg(req.path_constraints.position_constraints.front().constraint_region.primitive_poses.front(),
+               center_point_pose);
+
+  center_point_pose = scene->getFrameTransform(center_point_frame_id) * center_point_pose;
+
+  if (!req.goal_constraints.front().position_constraints.empty())
+  {
+    const moveit_msgs::Constraints& goal = req.goal_constraints.front();
+    geometry_msgs::Point center_point = tf2::toMsg(Eigen::Vector3d(center_point_pose.translation()));
+
+    info.circ_path_point.second = getConstraintPose(center_point, goal.orientation_constraints.front().orientation,
+                                                    goal.position_constraints.front().target_point_offset)
+                                      .translation();
+  }
+  else
+  {
+    info.circ_path_point.second = center_point_pose.translation();
   }
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -115,9 +115,12 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
     {
       frame_id = req.goal_constraints.front().position_constraints.front().header.frame_id;
     }
-    info.goal_pose = getConstraintPose(req.goal_constraints.front());
 
-    // check goal pose ik before Cartesian motion plan starts
+    // goal pose with optional offset wrt. the planning frame
+    info.goal_pose = scene->getFrameTransform(frame_id) * getConstraintPose(req.goal_constraints.front());
+    frame_id = robot_model_->getModelFrame();
+
+    // check goal pose ik before Cartesian motion plan start
     std::map<std::string, double> ik_solution;
     if (!computePoseIK(scene, info.group_name, info.link_name, info.goal_pose, frame_id, info.start_joint_position,
                        ik_solution))

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -69,7 +69,6 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
   ROS_DEBUG("Extract necessary information from motion plan request.");
 
   info.group_name = req.group_name;
-  std::string frame_id{ robot_model_->getModelFrame() };
   robot_state::RobotState robot_state = scene->getCurrentState();
 
   // goal given in joint space
@@ -103,6 +102,8 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
   // goal given in Cartesian space
   else
   {
+    std::string frame_id;
+
     info.link_name = req.goal_constraints.front().position_constraints.front().link_name;
     if (req.goal_constraints.front().position_constraints.front().header.frame_id.empty() ||
         req.goal_constraints.front().orientation_constraints.front().header.frame_id.empty())

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -116,19 +116,19 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
       frame_id = req.goal_constraints.front().position_constraints.front().header.frame_id;
     }
     info.goal_pose = getConstraintPose(req.goal_constraints.front());
+
+    // check goal pose ik before Cartesian motion plan starts
+    std::map<std::string, double> ik_solution;
+    if (!computePoseIK(scene, info.group_name, info.link_name, info.goal_pose, frame_id, info.start_joint_position,
+                       ik_solution))
+    {
+      std::ostringstream os;
+      os << "Failed to compute inverse kinematics for link: " << info.link_name << " of goal pose";
+      throw LinInverseForGoalIncalculable(os.str());
+    }
   }
 
   computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose);
-
-  // check goal pose ik before Cartesian motion plan starts
-  std::map<std::string, double> ik_solution;
-  if (!computePoseIK(scene, info.group_name, info.link_name, info.goal_pose, frame_id, info.start_joint_position,
-                     ik_solution))
-  {
-    std::ostringstream os;
-    os << "Failed to compute inverse kinematics for link: " << info.link_name << " of goal pose";
-    throw LinInverseForGoalIncalculable(os.str());
-  }
 }
 
 void TrajectoryGeneratorLIN::plan(const planning_scene::PlanningSceneConstPtr& scene,

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -217,11 +217,32 @@ void TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_scene::Plannin
   // solve the ik
   else
   {
-    Eigen::Isometry3d goal_pose = getConstraintPose(req.goal_constraints.front());
-    if (!computePoseIK(scene, req.group_name, req.goal_constraints.at(0).position_constraints.at(0).link_name,
-                       goal_pose, robot_model_->getModelFrame(), info.start_joint_position, info.goal_joint_position))
+    std::string frame_id;
+
+    info.link_name = req.goal_constraints.front().position_constraints.front().link_name;
+    if (req.goal_constraints.front().position_constraints.front().header.frame_id.empty() ||
+        req.goal_constraints.front().orientation_constraints.front().header.frame_id.empty())
     {
-      throw PtpNoIkSolutionForGoalPose("No IK solution for goal pose");
+      ROS_WARN("Frame id is not set in position/orientation constraints of "
+               "goal. Use model frame as default");
+      frame_id = robot_model_->getModelFrame();
+    }
+    else
+    {
+      frame_id = req.goal_constraints.front().position_constraints.front().header.frame_id;
+    }
+
+    // goal pose with optional offset wrt. the planning frame
+    info.goal_pose = scene->getFrameTransform(frame_id) * getConstraintPose(req.goal_constraints.front());
+    frame_id = robot_model_->getModelFrame();
+
+    // check goal pose ik before Cartesian motion plan start
+    if (!computePoseIK(scene, info.group_name, info.link_name, info.goal_pose, frame_id, info.start_joint_position,
+                       info.goal_joint_position))
+    {
+      std::ostringstream os;
+      os << "Failed to compute inverse kinematics for link: " << info.link_name << " of goal pose";
+      throw PtpNoIkSolutionForGoalPose(os.str());
     }
   }
 }


### PR DESCRIPTION
### Description

Should fix #3035 (partially) and ros-planning/moveit_task_constructor/issues/411 by transforming the goal pose (CIRC, LIN and PTP) and the center point (CIRC) wrt. the planning frame.

Only computes the IK when there is a goal pose constraint. Removed unused `frame_id` initialisation. Transforms the goal pose for `CIRC`, `LIN` and `PTP` wrt. the planning frame. Transform the center point for `CIRC` wrt. the planning frame.

Rebased on #3519.

**TODO**
- [x] Fix CIRC
- [x] Fix LIN and PTP
- [ ] Add unit tests
- [ ] Update [moveit_tutorials](https://github.com/ros-planning/moveit_tutorials) doc for goals in cartesian space as well as interim/center point -> all frames are resolved with the start pose

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"

---
**This post has been edited prior discussion with the maintainers** 