### PR TITLE
Fix Pilz planner: consider link_name offset during IK computation

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -71,9 +71,10 @@ bool computePoseIK(const planning_scene::PlanningSceneConstPtr& scene, const std
                    bool check_self_collision = true, const double timeout = 0.0);
 
 bool computePoseIK(const planning_scene::PlanningSceneConstPtr& scene, const std::string& group_name,
-                   const std::string& link_name, const geometry_msgs::Pose& pose, const std::string& frame_id,
-                   const std::map<std::string, double>& seed, std::map<std::string, double>& solution,
-                   bool check_self_collision = true, const double timeout = 0.0);
+                   const std::string& link_name, const Eigen::Translation3d& offset, const geometry_msgs::Pose& pose,
+                   const std::string& frame_id, const std::map<std::string, double>& seed,
+                   std::map<std::string, double>& solution, bool check_self_collision = true,
+                   const double timeout = 0.0);
 
 /**
  * @brief compute the pose of a link at given robot state
@@ -116,6 +117,7 @@ bool verifySampleJointLimits(const std::map<std::string, double>& position_last,
  * @param trajectory: KDL Cartesian trajectory
  * @param group_name: name of the planning group
  * @param link_name: name of the target robot link
+ * @param offset: (inverse) offset from link name to IK solver frame
  * @param initial_joint_position: initial joint positions, needed for selecting
  * the ik solution
  * @param sampling_time: sampling time of the generated trajectory
@@ -129,6 +131,7 @@ bool verifySampleJointLimits(const std::map<std::string, double>& position_last,
 bool generateJointTrajectory(const planning_scene::PlanningSceneConstPtr& scene,
                              const JointLimitsContainer& joint_limits, const KDL::Trajectory& trajectory,
                              const std::string& group_name, const std::string& link_name,
+                             const Eigen::Translation3d& offset,
                              const std::map<std::string, double>& initial_joint_position, const double& sampling_time,
                              trajectory_msgs::JointTrajectory& joint_trajectory,
                              moveit_msgs::MoveItErrorCodes& error_code, bool check_self_collision = false);
@@ -147,6 +150,7 @@ bool generateJointTrajectory(const planning_scene::PlanningSceneConstPtr& scene,
                              const JointLimitsContainer& joint_limits,
                              const pilz_industrial_motion_planner::CartesianTrajectory& trajectory,
                              const std::string& group_name, const std::string& link_name,
+                             const Eigen::Translation3d& offset,
                              const std::map<std::string, double>& initial_joint_position,
                              const std::map<std::string, double>& initial_joint_velocity,
                              trajectory_msgs::JointTrajectory& joint_trajectory,

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -222,18 +222,16 @@ bool isStateColliding(const planning_scene::PlanningSceneConstPtr& scene, robot_
 void normalizeQuaternion(geometry_msgs::Quaternion& quat);
 
 /**
- * @brief Adapt goal pose, defined by position+orientation, to consider offset
- * @param constraint to apply offset to
- * @param offset to apply to the constraint
- * @param orientation to apply to the offset
- * @return final goal pose
+ * @brief Compose pose from position and orientation
+ * @param position
+ * @param orientation
+ * @return pose
  */
-Eigen::Isometry3d getConstraintPose(const geometry_msgs::Point& position, const geometry_msgs::Quaternion& orientation,
-                                    const geometry_msgs::Vector3& offset);
+Eigen::Isometry3d getPose(const geometry_msgs::Point& position, const geometry_msgs::Quaternion& orientation);
 
 /**
  * @brief Conviencency method, passing args from a goal constraint
  * @param goal goal constraint
- * @return final goal pose
+ * @return pose
  */
-Eigen::Isometry3d getConstraintPose(const moveit_msgs::Constraints& goal);
+Eigen::Isometry3d getPose(const moveit_msgs::Constraints& goal);

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -120,6 +120,7 @@ protected:
 
     std::string group_name;
     std::string link_name;
+    Eigen::Translation3d ioffset;  // inverse offset from link_name to IK point
     Eigen::Isometry3d start_pose;
     Eigen::Isometry3d goal_pose;
     std::map<std::string, double> start_joint_position;

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
@@ -90,8 +90,8 @@ bool pilz_industrial_motion_planner::TrajectoryBlenderTransitionWindow::blend(
   moveit_msgs::MoveItErrorCodes error_code;
 
   if (!generateJointTrajectory(planning_scene, limits_.getJointLimitContainer(), blend_trajectory_cartesian,
-                               req.group_name, req.link_name, initial_joint_position, initial_joint_velocity,
-                               blend_joint_trajectory, error_code))
+                               req.group_name, req.link_name, Eigen::Translation3d::Identity(), initial_joint_position,
+                               initial_joint_velocity, blend_joint_trajectory, error_code))
   {
     // LCOV_EXCL_START
     ROS_INFO("Failed to generate joint trajectory for blending trajectory.");

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -572,25 +572,20 @@ void normalizeQuaternion(geometry_msgs::Quaternion& quat)
   quat = tf2::toMsg(q.normalize());
 }
 
-Eigen::Isometry3d getConstraintPose(const geometry_msgs::Point& position, const geometry_msgs::Quaternion& orientation,
-                                    const geometry_msgs::Vector3& offset)
+Eigen::Isometry3d getPose(const geometry_msgs::Point& position, const geometry_msgs::Quaternion& orientation)
 {
   Eigen::Quaterniond quat;
   tf2::fromMsg(orientation, quat);
   quat.normalize();
+
   Eigen::Vector3d v;
   tf2::fromMsg(position, v);
 
-  Eigen::Isometry3d pose = Eigen::Translation3d(v) * quat;
-
-  tf2::fromMsg(offset, v);
-  pose.translation() -= quat * v;
-  return pose;
+  return Eigen::Translation3d(v) * quat;
 }
 
-Eigen::Isometry3d getConstraintPose(const moveit_msgs::Constraints& goal)
+Eigen::Isometry3d getPose(const moveit_msgs::Constraints& goal)
 {
-  return getConstraintPose(goal.position_constraints.front().constraint_region.primitive_poses.front().position,
-                           goal.orientation_constraints.front().orientation,
-                           goal.position_constraints.front().target_point_offset);
+  return getPose(goal.position_constraints.front().constraint_region.primitive_poses.front().position,
+                 goal.orientation_constraints.front().orientation);
 }

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -93,15 +93,16 @@ bool pilz_industrial_motion_planner::computePoseIK(const planning_scene::Plannin
 
 bool pilz_industrial_motion_planner::computePoseIK(const planning_scene::PlanningSceneConstPtr& scene,
                                                    const std::string& group_name, const std::string& link_name,
-                                                   const geometry_msgs::Pose& pose, const std::string& frame_id,
+                                                   const Eigen::Translation3d& offset, const geometry_msgs::Pose& pose,
+                                                   const std::string& frame_id,
                                                    const std::map<std::string, double>& seed,
                                                    std::map<std::string, double>& solution, bool check_self_collision,
                                                    const double timeout)
 {
   Eigen::Isometry3d pose_eigen;
   tf2::fromMsg(pose, pose_eigen);
-  return computePoseIK(scene, group_name, link_name, pose_eigen, frame_id, seed, solution, check_self_collision,
-                       timeout);
+  return computePoseIK(scene, group_name, link_name, pose_eigen * offset, frame_id, seed, solution,
+                       check_self_collision, timeout);
 }
 
 bool pilz_industrial_motion_planner::computeLinkFK(robot_state::RobotState& robot_state, const std::string& link_name,
@@ -186,7 +187,7 @@ bool pilz_industrial_motion_planner::verifySampleJointLimits(
 bool pilz_industrial_motion_planner::generateJointTrajectory(
     const planning_scene::PlanningSceneConstPtr& scene,
     const pilz_industrial_motion_planner::JointLimitsContainer& joint_limits, const KDL::Trajectory& trajectory,
-    const std::string& group_name, const std::string& link_name,
+    const std::string& group_name, const std::string& link_name, const Eigen::Translation3d& offset,
     const std::map<std::string, double>& initial_joint_position, const double& sampling_time,
     trajectory_msgs::JointTrajectory& joint_trajectory, moveit_msgs::MoveItErrorCodes& error_code,
     bool check_self_collision)
@@ -219,8 +220,8 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
   {
     tf2::fromMsg(tf2::toMsg(trajectory.Pos(*time_iter)), pose_sample);
 
-    if (!computePoseIK(scene, group_name, link_name, pose_sample, robot_model->getModelFrame(), ik_solution_last,
-                       ik_solution, check_self_collision))
+    if (!computePoseIK(scene, group_name, link_name, pose_sample * offset, robot_model->getModelFrame(),
+                       ik_solution_last, ik_solution, check_self_collision))
     {
       ROS_ERROR("Failed to compute inverse kinematics solution for sampled "
                 "Cartesian pose.");
@@ -303,7 +304,8 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
     const planning_scene::PlanningSceneConstPtr& scene,
     const pilz_industrial_motion_planner::JointLimitsContainer& joint_limits,
     const pilz_industrial_motion_planner::CartesianTrajectory& trajectory, const std::string& group_name,
-    const std::string& link_name, const std::map<std::string, double>& initial_joint_position,
+    const std::string& link_name, const Eigen::Translation3d& offset,
+    const std::map<std::string, double>& initial_joint_position,
     const std::map<std::string, double>& initial_joint_velocity, trajectory_msgs::JointTrajectory& joint_trajectory,
     moveit_msgs::MoveItErrorCodes& error_code, bool check_self_collision)
 {
@@ -325,7 +327,7 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
   for (size_t i = 0; i < trajectory.points.size(); ++i)
   {
     // compute inverse kinematics
-    if (!computePoseIK(scene, group_name, link_name, trajectory.points.at(i).pose, robot_model->getModelFrame(),
+    if (!computePoseIK(scene, group_name, link_name, offset, trajectory.points.at(i).pose, robot_model->getModelFrame(),
                        ik_solution_last, ik_solution, check_self_collision))
     {
       ROS_ERROR("Failed to compute inverse kinematics solution for sampled "

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -146,7 +146,7 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
     }
 
     // goal pose with optional offset wrt. the planning frame
-    info.goal_pose = scene->getFrameTransform(frame_id) * getConstraintPose(req.goal_constraints.front());
+    info.goal_pose = scene->getFrameTransform(frame_id) * getPose(req.goal_constraints.front());
     frame_id = robot_model_->getModelFrame();
 
     // check goal pose ik before Cartesian motion plan start
@@ -164,40 +164,18 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
   }
   computeLinkFK(robot_state, info.link_name, info.start_joint_position, info.start_pose);
 
-  // center point with wrt. the planning frame
-  std::string center_point_frame_id;
-
+  // center point's frame_id
+  std::string center_point_frame_id = req.path_constraints.position_constraints.front().header.frame_id;
   info.circ_path_point.first = req.path_constraints.name;
-  if (req.path_constraints.position_constraints.front().header.frame_id.empty())
+  if (center_point_frame_id.empty())
   {
-    ROS_WARN("Frame id is not set in position constraints of "
-             "path. Use model frame as default");
+    ROS_WARN_STREAM("No frame_id specified in path constraint for circle " << req.path_constraints.name << " point. "
+                                                                           << "Using model frame as fallback.");
     center_point_frame_id = robot_model_->getModelFrame();
   }
-  else
-  {
-    center_point_frame_id = req.path_constraints.position_constraints.front().header.frame_id;
-  }
-
-  Eigen::Isometry3d center_point_pose;
-  tf2::fromMsg(req.path_constraints.position_constraints.front().constraint_region.primitive_poses.front(),
-               center_point_pose);
-
-  center_point_pose = scene->getFrameTransform(center_point_frame_id) * center_point_pose;
-
-  if (!req.goal_constraints.front().position_constraints.empty())
-  {
-    const moveit_msgs::Constraints& goal = req.goal_constraints.front();
-    geometry_msgs::Point center_point = tf2::toMsg(Eigen::Vector3d(center_point_pose.translation()));
-
-    info.circ_path_point.second = getConstraintPose(center_point, goal.orientation_constraints.front().orientation,
-                                                    goal.position_constraints.front().target_point_offset)
-                                      .translation();
-  }
-  else
-  {
-    info.circ_path_point.second = center_point_pose.translation();
-  }
+  tf2::fromMsg(req.path_constraints.position_constraints.front().constraint_region.primitive_poses.front().position,
+               info.circ_path_point.second);
+  info.circ_path_point.second = scene->getFrameTransform(center_point_frame_id) * info.circ_path_point.second;
 }
 
 void TrajectoryGeneratorCIRC::plan(const planning_scene::PlanningSceneConstPtr& scene,

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -118,7 +118,7 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
     }
 
     // goal pose with optional offset wrt. the planning frame
-    info.goal_pose = scene->getFrameTransform(frame_id) * getConstraintPose(req.goal_constraints.front());
+    info.goal_pose = scene->getFrameTransform(frame_id) * getPose(req.goal_constraints.front());
     frame_id = robot_model_->getModelFrame();
 
     // check goal pose ik before Cartesian motion plan start

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -233,7 +233,7 @@ void TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_scene::Plannin
     }
 
     // goal pose with optional offset wrt. the planning frame
-    info.goal_pose = scene->getFrameTransform(frame_id) * getConstraintPose(req.goal_constraints.front());
+    info.goal_pose = scene->getFrameTransform(frame_id) * getPose(req.goal_constraints.front());
     frame_id = robot_model_->getModelFrame();
 
     // check goal pose ik before Cartesian motion plan start

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -220,6 +220,9 @@ void TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_scene::Plannin
     std::string frame_id;
 
     info.link_name = req.goal_constraints.front().position_constraints.front().link_name;
+    const auto& offset = req.goal_constraints.front().position_constraints.front().target_point_offset;
+    info.ioffset = Eigen::Translation3d(offset.x, offset.y, offset.z).inverse();
+
     if (req.goal_constraints.front().position_constraints.front().header.frame_id.empty() ||
         req.goal_constraints.front().orientation_constraints.front().header.frame_id.empty())
     {
@@ -237,8 +240,8 @@ void TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_scene::Plannin
     frame_id = robot_model_->getModelFrame();
 
     // check goal pose ik before Cartesian motion plan start
-    if (!computePoseIK(scene, info.group_name, info.link_name, info.goal_pose, frame_id, info.start_joint_position,
-                       info.goal_joint_position))
+    if (!computePoseIK(scene, info.group_name, info.link_name, info.goal_pose * info.ioffset, frame_id,
+                       info.start_joint_position, info.goal_joint_position))
     {
       std::ostringstream os;
       os << "Failed to compute inverse kinematics for link: " << info.link_name << " of goal pose";

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_blender_transition_window.cpp
@@ -684,8 +684,8 @@ TEST_P(TrajectoryBlenderTransitionWindowTest, testNonLinearBlending)
 
     moveit_msgs::MoveItErrorCodes error_code;
     if (!generateJointTrajectory(planning_scene_, planner_limits_.getJointLimitContainer(), cart_traj, planning_group_,
-                                 target_link_, initial_joint_position, initial_joint_velocity, joint_traj, error_code,
-                                 true))
+                                 target_link_, Eigen::Translation3d::Identity(), initial_joint_position,
+                                 initial_joint_velocity, joint_traj, error_code, true))
     {
       std::runtime_error("Failed to generate trajectory.");
     }

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_functions.cpp
@@ -701,8 +701,8 @@ TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testGenerateJointTrajectoryWithI
   bool check_self_collision{ false };
 
   EXPECT_FALSE(pilz_industrial_motion_planner::generateJointTrajectory(
-      planning_scene_, joint_limits, kdl_trajectory, group_name, tcp_link_, initial_joint_position, sampling_time,
-      joint_trajectory, error_code, check_self_collision));
+      planning_scene_, joint_limits, kdl_trajectory, group_name, tcp_link_, Eigen::Translation3d::Identity(),
+      initial_joint_position, sampling_time, joint_trajectory, error_code, check_self_collision));
 
   std::map<std::string, double> initial_joint_velocity;
 
@@ -713,8 +713,8 @@ TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testGenerateJointTrajectoryWithI
   cart_traj.points.push_back(cart_traj_point);
 
   EXPECT_FALSE(pilz_industrial_motion_planner::generateJointTrajectory(
-      planning_scene_, joint_limits, cart_traj, group_name, tcp_link_, initial_joint_position, initial_joint_velocity,
-      joint_trajectory, error_code, check_self_collision));
+      planning_scene_, joint_limits, cart_traj, group_name, tcp_link_, Eigen::Translation3d::Identity(),
+      initial_joint_position, initial_joint_velocity, joint_trajectory, error_code, check_self_collision));
 }
 
 /**


### PR DESCRIPTION
Implement https://github.com/ros-planning/moveit/pull/3519#issuecomment-1804927996:

Trajectory generation needs to use the actual link_name's (and its offset's) start and goal pose in order to realize a straigh-line motion. We must not back-project the offset to the associated robot link. Instead, we need to consider the offset during computation of the IK. I implemented this for the CartesianInterpolator in #3197.

Unfortunately, the unit tests don't cover those cases yet - they only consider the final goal pose, but don't check the path in between :disappointed: 

https://github.com/ros-planning/moveit/assets/5376030/ae0bf3e2-3c2f-496c-8bc3-1d5b152c4f14

https://github.com/ros-planning/moveit/assets/5376030/ba6bde21-895f-4c26-930a-221ad0a00f12

