### PR TITLE
Fix Pilz unit tests: correctly transforms the goal pose and center point  wrt. the planning frame

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_command_planning.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/integrationtest_command_planning.cpp
@@ -238,6 +238,7 @@ TEST_F(IntegrationTestCommandPlanning, PtpJointCart)
  */
 TEST_F(IntegrationTestCommandPlanning, LinJoint)
 {
+  robot_model::RobotState robot_state(robot_model_);
   planning_interface::MotionPlanRequest req{ test_data_->getLinJoint("lin2").toRequest() };
 
   std::cout << "++++++++++" << std::endl;
@@ -259,7 +260,7 @@ TEST_F(IntegrationTestCommandPlanning, LinJoint)
   std::cout << "+ Step 2 +" << std::endl;
   std::cout << "++++++++++" << std::endl;
 
-  ASSERT_TRUE(testutils::isGoalReached(robot_model_, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
+  ASSERT_TRUE(testutils::isGoalReached(robot_state, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
                                        orientation_norm_tolerance_))
       << "Goal not reached.";
 
@@ -267,7 +268,7 @@ TEST_F(IntegrationTestCommandPlanning, LinJoint)
   std::cout << "+ Step 3 +" << std::endl;
   std::cout << "++++++++++" << std::endl;
 
-  ASSERT_TRUE(testutils::checkCartesianLinearity(robot_model_, response.trajectory.joint_trajectory, req,
+  ASSERT_TRUE(testutils::checkCartesianLinearity(robot_state, response.trajectory.joint_trajectory, req,
                                                  pose_norm_tolerance_, orientation_norm_tolerance_))
       << "Trajectory violates cartesian linearity.";
 }
@@ -290,6 +291,7 @@ TEST_F(IntegrationTestCommandPlanning, LinJoint)
 TEST_F(IntegrationTestCommandPlanning, LinJointCart)
 {
   ros::NodeHandle node_handle("~");
+  robot_model::RobotState robot_state(robot_model_);
   planning_interface::MotionPlanRequest req{ test_data_->getLinJointCart("lin2").toRequest() };
 
   std::cout << "++++++++++" << std::endl;
@@ -310,7 +312,7 @@ TEST_F(IntegrationTestCommandPlanning, LinJointCart)
   std::cout << "+ Step 2 +" << std::endl;
   std::cout << "++++++++++" << std::endl;
 
-  ASSERT_TRUE(testutils::isGoalReached(robot_model_, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
+  ASSERT_TRUE(testutils::isGoalReached(robot_state, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
                                        orientation_norm_tolerance_))
       << "Goal not reached.";
 
@@ -318,7 +320,7 @@ TEST_F(IntegrationTestCommandPlanning, LinJointCart)
   std::cout << "+ Step 3 +" << std::endl;
   std::cout << "++++++++++" << std::endl;
 
-  ASSERT_TRUE(testutils::checkCartesianLinearity(robot_model_, response.trajectory.joint_trajectory, req,
+  ASSERT_TRUE(testutils::checkCartesianLinearity(robot_state, response.trajectory.joint_trajectory, req,
                                                  pose_norm_tolerance_, orientation_norm_tolerance_))
       << "Trajectory violates cartesian linearity.";
 }
@@ -338,6 +340,7 @@ TEST_F(IntegrationTestCommandPlanning, LinJointCart)
 TEST_F(IntegrationTestCommandPlanning, CircJointCenterCart)
 {
   ros::NodeHandle node_handle("~");
+  robot_model::RobotState robot_state(robot_model_);
 
   CircJointCenterCart circ{ test_data_->getCircJointCenterCart("circ1_center_2") };
 
@@ -367,7 +370,7 @@ TEST_F(IntegrationTestCommandPlanning, CircJointCenterCart)
   }
 
   // check goal is reached
-  ASSERT_TRUE(testutils::isGoalReached(robot_model_, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
+  ASSERT_TRUE(testutils::isGoalReached(robot_state, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
                                        orientation_norm_tolerance_))
       << "Goal not reached.";
 
@@ -423,6 +426,7 @@ TEST_F(IntegrationTestCommandPlanning, CircJointCenterCart)
 TEST_F(IntegrationTestCommandPlanning, CircCartCenterCart)
 {
   ros::NodeHandle node_handle("~");
+  robot_model::RobotState robot_state(robot_model_);
 
   CircCenterCart circ{ test_data_->getCircCartCenterCart("circ1_center_2") };
   moveit_msgs::MotionPlanRequest req{ circ.toRequest() };
@@ -450,7 +454,7 @@ TEST_F(IntegrationTestCommandPlanning, CircCartCenterCart)
   }
 
   // check goal is reached
-  ASSERT_TRUE(testutils::isGoalReached(robot_model_, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
+  ASSERT_TRUE(testutils::isGoalReached(robot_state, response.trajectory.joint_trajectory, req, pose_norm_tolerance_,
                                        orientation_norm_tolerance_))
       << "Goal not reached.";
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
@@ -100,14 +100,17 @@ bool testutils::getExpectedGoalPose(const robot_state::RobotState& robot_state,
   // ++++++++++++++++++++++++++++++++++++++
   // + Get goal from cartesian constraint +
   // ++++++++++++++++++++++++++++++++++++++
-  // TODO frame id
+  robot_state::RobotState start_state = robot_state::RobotState(robot_state);
+
+  for (std::size_t i = 0; i < req.start_state.joint_state.name.size(); ++i)
+    start_state.setJointPositions(req.start_state.joint_state.name[i], &req.start_state.joint_state.position[i]);
+  start_state.update();
+
   link_name = req.goal_constraints.front().position_constraints.front().link_name;
-  geometry_msgs::Pose goal_pose_msg;
-  goal_pose_msg.position =
-      req.goal_constraints.front().position_constraints.front().constraint_region.primitive_poses.front().position;
-  goal_pose_msg.orientation = req.goal_constraints.front().orientation_constraints.front().orientation;
-  normalizeQuaternion(goal_pose_msg.orientation);
-  tf2::fromMsg(goal_pose_msg, goal_pose_expect);
+  goal_pose_expect =
+      start_state.getFrameTransform(req.goal_constraints.front().position_constraints.front().header.frame_id) *
+      getConstraintPose(req.goal_constraints.front());
+
   return true;
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
@@ -150,9 +150,8 @@ inline moveit_msgs::Constraints generateJointConstraint(const std::vector<double
  * @brief Determines the goal position from the given request.
  * TRUE if successful, FALSE otherwise.
  */
-bool getExpectedGoalPose(const moveit::core::RobotModelConstPtr& robot_model,
-                         const planning_interface::MotionPlanRequest& req, std::string& link_name,
-                         Eigen::Isometry3d& goal_pose_expect);
+bool getExpectedGoalPose(const moveit::core::RobotState& robot_state, const planning_interface::MotionPlanRequest& req,
+                         std::string& link_name, Eigen::Isometry3d& goal_pose_expect);
 
 /**
  * @brief create a dummy motion plan request with zero start state
@@ -183,25 +182,24 @@ bool isGoalReached(const trajectory_msgs::JointTrajectory& trajectory,
 /**
  * @brief check if the goal given in cartesian space is reached
  * Only the last point in the trajectory is veryfied.
- * @param robot_model
+ * @param robot_state
  * @param trajectory
  * @param req
  * @param matrix_norm_tolerance: used to compare the transformation matrix
  * @param joint_velocity_tolerance
  * @return
  */
-bool isGoalReached(const robot_model::RobotModelConstPtr& robot_model,
-                   const trajectory_msgs::JointTrajectory& trajectory, const planning_interface::MotionPlanRequest& req,
-                   const double pos_tolerance, const double orientation_tolerance);
+bool isGoalReached(const robot_model::RobotState& robot_state, const trajectory_msgs::JointTrajectory& trajectory,
+                   const planning_interface::MotionPlanRequest& req, const double pos_tolerance,
+                   const double orientation_tolerance);
 
-bool isGoalReached(const moveit::core::RobotModelConstPtr& robot_model,
-                   const trajectory_msgs::JointTrajectory& trajectory, const planning_interface::MotionPlanRequest& req,
-                   const double tolerance);
+bool isGoalReached(const moveit::core::RobotState& robot_state, const trajectory_msgs::JointTrajectory& trajectory,
+                   const planning_interface::MotionPlanRequest& req, const double tolerance);
 
 /**
  * @brief Check that given trajectory is straight line.
  */
-bool checkCartesianLinearity(const robot_model::RobotModelConstPtr& robot_model,
+bool checkCartesianLinearity(const robot_model::RobotState& robot_state,
                              const trajectory_msgs::JointTrajectory& trajectory,
                              const planning_interface::MotionPlanRequest& req, const double translation_norm_tolerance,
                              const double rot_axis_norm_tolerance, const double rot_angle_tolerance = 10e-5);
@@ -291,26 +289,26 @@ bool isAccelerationBounded(const trajectory_msgs::JointTrajectory& trajectory,
 
 /**
  * @brief compute the tcp pose from joint values
- * @param robot_model
+ * @param robot_state
  * @param link_name
  * @param joint_values
  * @param pose
  * @param joint_prefix Prefix of the joint names
  * @return false if forward kinematics failed
  */
-bool toTCPPose(const moveit::core::RobotModelConstPtr& robot_model, const std::string& link_name,
+bool toTCPPose(const robot_state::RobotState& robot_state, const std::string& link_name,
                const std::vector<double>& joint_values, geometry_msgs::Pose& pose,
                const std::string& joint_prefix = testutils::JOINT_NAME_PREFIX);
 
 /**
  * @brief computeLinkFK
- * @param robot_model
+ * @param robot_state
  * @param link_name
  * @param joint_state
  * @param pose
  * @return
  */
-bool computeLinkFK(const robot_model::RobotModelConstPtr& robot_model, const std::string& link_name,
+bool computeLinkFK(const robot_state::RobotState& robot_state, const std::string& link_name,
                    const std::map<std::string, double>& joint_state, Eigen::Isometry3d& pose);
 
 /**

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_generator_circ.cpp
@@ -151,8 +151,7 @@ void TrajectoryGeneratorCIRCTest::checkCircResult(const robot_model::RobotState&
 {
   moveit_msgs::MotionPlanResponse res_msg;
   res.getMessage(res_msg);
-  EXPECT_TRUE(testutils::isGoalReached(res.trajectory_->getFirstWayPointPtr()->getRobotModel(),
-                                       res_msg.trajectory.joint_trajectory, req, other_tolerance_));
+  EXPECT_TRUE(testutils::isGoalReached(robot_state, res_msg.trajectory.joint_trajectory, req, other_tolerance_));
 
   EXPECT_TRUE(
       testutils::checkJointTrajectory(res_msg.trajectory.joint_trajectory, planner_limits_.getJointLimitContainer()));

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_generator_lin.cpp
@@ -151,12 +151,14 @@ bool TrajectoryGeneratorLINTest::checkLinResponse(const planning_interface::Moti
 {
   moveit_msgs::MotionPlanResponse res_msg;
   res.getMessage(res_msg);
-  if (!testutils::isGoalReached(robot_model_, res_msg.trajectory.joint_trajectory, req, pose_norm_tolerance_))
+
+  robot_model::RobotState robot_state = planning_scene_->getCurrentState();
+  if (!testutils::isGoalReached(robot_state, res_msg.trajectory.joint_trajectory, req, pose_norm_tolerance_))
   {
     return false;
   }
 
-  if (!testutils::checkCartesianLinearity(robot_model_, res_msg.trajectory.joint_trajectory, req, pose_norm_tolerance_,
+  if (!testutils::checkCartesianLinearity(robot_state, res_msg.trajectory.joint_trajectory, req, pose_norm_tolerance_,
                                           rot_axis_norm_tolerance_))
   {
     return false;

--- a/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/unittest_trajectory_generator_ptp.cpp
@@ -378,7 +378,8 @@ TEST_P(TrajectoryGeneratorPTPTest, testCartesianGoal)
   }
 
   // check goal pose
-  EXPECT_TRUE(testutils::isGoalReached(robot_model_, res_msg.trajectory.joint_trajectory, req, pose_norm_tolerance_));
+  EXPECT_TRUE(testutils::isGoalReached(planning_scene_->getCurrentState(), res_msg.trajectory.joint_trajectory, req,
+                                       pose_norm_tolerance_));
 }
 
 /**


### PR DESCRIPTION
### Description

Unit tests for #3522. The tests for validating the goal pose and center circle had the same problem.

I had to pass the robot state instead of the robot model for the tests to pass (similar to #3519). Also reworked the center circle validation as well as the goal estimation.

Only added one test for CIRC for the moment.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
