### PR TITLE
Update ControllersWidget regex for valid controller names

### DIFF
--- a/moveit_setup_assistant/src/widgets/controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/controllers_widget.cpp
@@ -659,7 +659,7 @@ bool ControllersWidget::saveControllerScreen()
   moveit_setup_assistant::ControllerConfig* searched_controller = nullptr;
 
   std::smatch invalid_name_match;
-  std::regex invalid_reg_ex("[^a-z|^1-9|^_]");
+  std::regex invalid_reg_ex("[^a-z|^0-9|^_]");
 
   // Check that a valid controller name has been given
   if (controller_name.empty() || std::regex_search(controller_name, invalid_name_match, invalid_reg_ex))


### PR DESCRIPTION
### Description

Updated the regex pattern that validates controller names, to allow for the numerical `0` character. The intent is to allow for creation of controllers within MSA that follow the naming of move groups containing a `0` character. The validation of controller names is also not consistent between automatically generated and user created controllers.

**When using the "Auto Add..." button in the Setup Controllers widget, controllers are added for planning groups that have `0` characters in the group name. The generated controllers also contain `0` characters.** 

- Planning group:![planning-groups](https://github.com/ros-planning/moveit/assets/3058337/ca00bc0e-2611-442a-a804-8a839978fe8e)

- Auto-generated controller:![auto-add-controllers](https://github.com/ros-planning/moveit/assets/3058337/06e39438-30e2-4ccc-baf7-f5443c00368b)

**Attempting to modify the automatically generated controller and saving changes will present an error for an invalid controller name.**

- Error on saving: ![modify-auto-controller](https://github.com/ros-planning/moveit/assets/3058337/606eb652-1d7e-4bc6-a699-45128a1fcbff)

### Checklist
- [X] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
