### PR TITLE
Enable higher number of self-collision checking samples

### DIFF
--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -610,7 +610,7 @@ void disableNeverInCollisionThread(ThreadComputation tc)
   // ROS_INFO_STREAM("Thread " << tc.thread_id_ << " running " << tc.num_trials_ << " trials");
 
   // User feedback vars
-  const unsigned int progress_interval = tc.num_trials_ / 20;  // show progress update every 5%
+  const unsigned int progress_interval = tc.num_trials_ / 100;  // show progress update every 1%
 
   // Create a new kinematic state for this thread to work on
   moveit::core::RobotState robot_state(tc.scene_.getRobotModel());

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -610,7 +610,7 @@ void disableNeverInCollisionThread(ThreadComputation tc)
   // ROS_INFO_STREAM("Thread " << tc.thread_id_ << " running " << tc.num_trials_ << " trials");
 
   // User feedback vars
-  const unsigned int progress_interval = tc.num_trials_ / 100;  // show progress update every 1%
+  const unsigned int progress_interval = tc.num_trials_ / 20;  // show progress update every 5%
 
   // Create a new kinematic state for this thread to work on
   moveit::core::RobotState robot_state(tc.scene_.getRobotModel());

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -610,7 +610,7 @@ void disableNeverInCollisionThread(ThreadComputation tc)
   // ROS_INFO_STREAM("Thread " << tc.thread_id_ << " running " << tc.num_trials_ << " trials");
 
   // User feedback vars
-  const unsigned int progress_interval = tc.num_trials_ / 20;  // show progress update every 5%
+  const unsigned int progress_interval = std::max(1u, tc.num_trials_ / 100);  // show progress update every 1%
 
   // Create a new kinematic state for this thread to work on
   moveit::core::RobotState robot_state(tc.scene_.getRobotModel());

--- a/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
+++ b/moveit_setup_assistant/src/tools/compute_default_collisions.cpp
@@ -274,8 +274,6 @@ LinkPairMap computeDefaultCollisions(const planning_scene::PlanningSceneConstPtr
     */
   }
 
-  *progress = 100;  // end the status bar
-
   return link_pairs;
 }
 

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -296,8 +296,12 @@ void DefaultCollisionsWidget::interruptGeneratingCollisionTable()
                                                "Collision Matrix Generation is still active. Cancel computation?",
                                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No))
     return;
-  worker_->cancel();
-  worker_->wait();
+
+  if (worker_)
+  {
+    worker_->cancel();
+    worker_->wait();
+  }
 }
 
 // ******************************************************************************************
@@ -310,11 +314,11 @@ void DefaultCollisionsWidget::finishGeneratingCollisionTable()
     // Load the results into the GUI
     loadCollisionTable();
 
-    // Hide the progress bar
-    disableControls(false);  // enable everything else
-
     config_data_->changes |= MoveItConfigData::COLLISIONS;
   }
+  disableControls(false);  // enable controls, hide interrupt button + progress bar
+  progress_bar_->show();   // make progress bar visislbe again
+
   worker_->deleteLater();
   worker_ = nullptr;
 }
@@ -826,8 +830,11 @@ bool DefaultCollisionsWidget::focusLost()
                                                  "Collision Matrix Generation is still active. Cancel computation?",
                                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No))
       return false;
-    worker_->cancel();
-    worker_->wait();
+    if (worker_)
+    {
+      worker_->cancel();
+      worker_->wait();
+    }
   }
   *config_data_->srdf_ = *wip_srdf_;
 

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -298,16 +298,6 @@ void DefaultCollisionsWidget::interruptGeneratingCollisionTable()
     return;
   worker_->cancel();
   worker_->wait();
-
-  // Load the data to the table
-  loadCollisionTable();
-
-  // Hide the progress bar
-  disableControls(false);  // enable everything else
-
-  config_data_->changes |= MoveItConfigData::COLLISIONS;
-  worker_->deleteLater();
-  worker_ = nullptr;
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -129,15 +129,15 @@ DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, const MoveItCo
   // Slider
   density_slider_ = new QSlider(this);
   density_slider_->setTickPosition(QSlider::TicksBelow);
-  density_slider_->setMinimum(0);
-  density_slider_->setMaximum(99);
-  density_slider_->setSingleStep(10);
-  density_slider_->setPageStep(50);
-  density_slider_->setSliderPosition(9);  // 10,000 is default
-  density_slider_->setTickInterval(10);
+  density_slider_->setMinimum(1000);
+  density_slider_->setMaximum(100000);
+  density_slider_->setSingleStep(1000);
+  density_slider_->setPageStep(1000);
+  density_slider_->setSliderPosition(10000);  // 10,000 is default
+  density_slider_->setTickInterval(1000);
   density_slider_->setOrientation(Qt::Horizontal);
   slider_layout->addWidget(density_slider_);
-  connect(density_slider_, SIGNAL(valueChanged(int)), this, SLOT(changeDensitySpinbox(int)));
+  connect(density_slider_, SIGNAL(valueChanged(int)), this, SLOT(changeDensity(int)));
 
   // Slider Right Label
   QLabel* density_right_label = new QLabel(this);
@@ -152,8 +152,8 @@ DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, const MoveItCo
   density_value_spinbox_->setSingleStep(1000);
   density_value_spinbox_->setEnabled(true);
   slider_layout->addWidget(density_value_spinbox_);
-  changeDensitySpinbox(density_slider_->value());  // initialize label with value
-  connect(density_value_spinbox_, SIGNAL(valueChanged(int)), this, SLOT(changeDensitySlider(int)));
+  changeDensity(density_slider_->value());  // initialize label with value
+  connect(density_value_spinbox_, SIGNAL(valueChanged(int)), this, SLOT(changeDensity(int)));
 
   QHBoxLayout* buttons_layout = new QHBoxLayout();
   buttons_layout->setAlignment(Qt::AlignRight);
@@ -684,17 +684,14 @@ void DefaultCollisionsWidget::toggleSelection(QItemSelection selection)
 // ******************************************************************************************
 // GUI func for showing sampling density amount
 // ******************************************************************************************
-void DefaultCollisionsWidget::changeDensitySpinbox(int value)
+void DefaultCollisionsWidget::changeDensity(int value)
 {
   density_value_spinbox_->blockSignals(true);
-  density_value_spinbox_->setValue(value * 1000 + 1000); //.append(" samples") );
-  density_value_spinbox_->blockSignals(false);
-}
-
-void DefaultCollisionsWidget::changeDensitySlider(int value)
-{
   density_slider_->blockSignals(true);
-  density_slider_->setValue((value - 1000) / 1000);
+  int rounded_value = round(value/1000.0)*1000;
+  density_value_spinbox_->setValue(rounded_value);
+  density_slider_->setValue(rounded_value);
+  density_value_spinbox_->blockSignals(false);
   density_slider_->blockSignals(false);
 }
 

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -293,8 +293,8 @@ void DefaultCollisionsWidget::startGeneratingCollisionTable()
 void DefaultCollisionsWidget::interruptGeneratingCollisionTable()
 {
   if (QMessageBox::No == QMessageBox::question(this, "Collision Matrix Generation",
-                                                "Collision Matrix Generation is still active. Cancel computation?",
-                                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No))
+                                               "Collision Matrix Generation is still active. Cancel computation?",
+                                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No))
     return;
   worker_->cancel();
   worker_->wait();
@@ -334,7 +334,8 @@ void DefaultCollisionsWidget::finishGeneratingCollisionTable()
 // ******************************************************************************************
 void DefaultCollisionsWidget::generateCollisionTable(unsigned int* collision_progress)
 {
-  unsigned int num_trials = density_value_spinbox_->value();
+  unsigned int num_trials = (density_value_spinbox_->value() / 1000.0) * 1000;  // round the value in 1000s
+  num_trials = num_trials < 1000 ? 1000 : num_trials;                           // make sure that num_trials >= 1000
   double min_frac = (double)fraction_spinbox_->value() / 100.0;
 
   const bool verbose = true;  // Output benchmarking and statistics
@@ -719,8 +720,11 @@ void DefaultCollisionsWidget::changeDensity(int value)
   density_value_spinbox_->blockSignals(true);
   density_slider_->blockSignals(true);
 
-  int rounded_value = round(value/1000.0)*1000;
-  density_value_spinbox_->setValue(rounded_value);
+  int rounded_value = round(value / 1000.0) * 1000;
+  if (density_value_spinbox_->hasFocus() == false)
+  {
+    density_value_spinbox_->setValue(rounded_value);
+  }
   density_slider_->setValue(rounded_value);
 
   density_value_spinbox_->blockSignals(false);

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -721,7 +721,7 @@ void DefaultCollisionsWidget::changeDensity(int value)
   density_slider_->blockSignals(true);
 
   int rounded_value = round(value / 1000.0) * 1000;
-  if (density_value_spinbox_->hasFocus() == false)
+  if (!density_value_spinbox_->hasFocus())
   {
     density_value_spinbox_->setValue(rounded_value);
   }

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -341,8 +341,9 @@ void DefaultCollisionsWidget::generateCollisionTable(unsigned int* collision_pro
   // Update collision_matrix for robot pose's use
   config_data_->loadAllowedCollisionMatrix(*wip_srdf_);
 
-  // End the progress bar loop
-  *collision_progress = 100;
+  // Indicate end the progress bar loop (MonitorThread::run())
+  if (worker_ && !worker_->canceled())
+    *collision_progress = 100;
 
   ROS_INFO_STREAM("Thread complete " << link_pairs.size());
 }
@@ -859,7 +860,6 @@ void moveit_setup_assistant::MonitorThread::run()
 
   worker_.join();
 
-  progress_ = 100;
   Q_EMIT progress(progress_);
 }
 

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -137,18 +137,23 @@ DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, const MoveItCo
   density_slider_->setTickInterval(10);
   density_slider_->setOrientation(Qt::Horizontal);
   slider_layout->addWidget(density_slider_);
-  connect(density_slider_, SIGNAL(valueChanged(int)), this, SLOT(changeDensityLabel(int)));
+  connect(density_slider_, SIGNAL(valueChanged(int)), this, SLOT(changeDensitySpinbox(int)));
 
   // Slider Right Label
   QLabel* density_right_label = new QLabel(this);
   density_right_label->setText("High   ");
   slider_layout->addWidget(density_right_label);
 
-  // Slider Value Label
-  density_value_label_ = new QLabel(this);
-  density_value_label_->setMinimumWidth(50);
-  slider_layout->addWidget(density_value_label_);
-  changeDensityLabel(density_slider_->value());  // initialize label with value
+  // Spinbox Value Label
+  density_value_spinbox_ = new QSpinBox(this);
+  density_value_spinbox_->setMinimumWidth(70);
+  density_value_spinbox_->setMinimum(1000);
+  density_value_spinbox_->setMaximum(100000000);
+  density_value_spinbox_->setSingleStep(1000);
+  density_value_spinbox_->setEnabled(true);
+  slider_layout->addWidget(density_value_spinbox_);
+  changeDensitySpinbox(density_slider_->value());  // initialize label with value
+  connect(density_value_spinbox_, SIGNAL(valueChanged(int)), this, SLOT(changeDensitySlider(int)));
 
   QHBoxLayout* buttons_layout = new QHBoxLayout();
   buttons_layout->setAlignment(Qt::AlignRight);
@@ -299,7 +304,7 @@ void DefaultCollisionsWidget::finishGeneratingCollisionTable()
 // ******************************************************************************************
 void DefaultCollisionsWidget::generateCollisionTable(unsigned int* collision_progress)
 {
-  unsigned int num_trials = density_slider_->value() * 1000 + 1000;  // scale to trials amount
+  unsigned int num_trials = density_value_spinbox_->value();
   double min_frac = (double)fraction_spinbox_->value() / 100.0;
 
   const bool verbose = true;  // Output benchmarking and statistics
@@ -679,9 +684,18 @@ void DefaultCollisionsWidget::toggleSelection(QItemSelection selection)
 // ******************************************************************************************
 // GUI func for showing sampling density amount
 // ******************************************************************************************
-void DefaultCollisionsWidget::changeDensityLabel(int value)
+void DefaultCollisionsWidget::changeDensitySpinbox(int value)
 {
-  density_value_label_->setText(QString::number(value * 1000 + 1000));  //.append(" samples") );
+  density_value_spinbox_->blockSignals(true);
+  density_value_spinbox_->setValue(value * 1000 + 1000); //.append(" samples") );
+  density_value_spinbox_->blockSignals(false);
+}
+
+void DefaultCollisionsWidget::changeDensitySlider(int value)
+{
+  density_slider_->blockSignals(true);
+  density_slider_->setValue((value - 1000) / 1000);
+  density_slider_->blockSignals(false);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -315,16 +315,16 @@ void DefaultCollisionsWidget::interruptGeneratingCollisionTable()
 // ******************************************************************************************
 void DefaultCollisionsWidget::finishGeneratingCollisionTable()
 {
-  if (worker_->canceled())
-    return;
+  if (!worker_->canceled())
+  {
+    // Load the results into the GUI
+    loadCollisionTable();
 
-  // Load the results into the GUI
-  loadCollisionTable();
+    // Hide the progress bar
+    disableControls(false);  // enable everything else
 
-  // Hide the progress bar
-  disableControls(false);  // enable everything else
-
-  config_data_->changes |= MoveItConfigData::COLLISIONS;
+    config_data_->changes |= MoveItConfigData::COLLISIONS;
+  }
   worker_->deleteLater();
   worker_ = nullptr;
 }

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -127,17 +127,17 @@ DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, const MoveItCo
   slider_layout->addWidget(density_left_label);
 
   // Slider
-  density_slider_ = new QSlider(this);
-  density_slider_->setTickPosition(QSlider::TicksBelow);
-  density_slider_->setMinimum(1000);
-  density_slider_->setMaximum(100000);
-  density_slider_->setSingleStep(1000);
-  density_slider_->setPageStep(10000);
-  density_slider_->setSliderPosition(10000);  // 10,000 is default
-  density_slider_->setTickInterval(10000);
-  density_slider_->setOrientation(Qt::Horizontal);
-  slider_layout->addWidget(density_slider_);
-  connect(density_slider_, SIGNAL(valueChanged(int)), this, SLOT(changeDensity(int)));
+  sample_slider_ = new QSlider(this);
+  sample_slider_->setTickPosition(QSlider::TicksBelow);
+  sample_slider_->setMinimum(1000);
+  sample_slider_->setMaximum(100000);
+  sample_slider_->setSingleStep(1000);
+  sample_slider_->setPageStep(10000);
+  sample_slider_->setSliderPosition(10000);  // 10,000 is default
+  sample_slider_->setTickInterval(10000);
+  sample_slider_->setOrientation(Qt::Horizontal);
+  slider_layout->addWidget(sample_slider_);
+  connect(sample_slider_, SIGNAL(valueChanged(int)), this, SLOT(changeNumSamples(int)));
 
   // Slider Right Label
   QLabel* density_right_label = new QLabel(this);
@@ -145,15 +145,15 @@ DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, const MoveItCo
   slider_layout->addWidget(density_right_label);
 
   // Spinbox Value Label
-  density_value_spinbox_ = new QSpinBox(this);
-  density_value_spinbox_->setMinimumWidth(70);
-  density_value_spinbox_->setMinimum(1000);
-  density_value_spinbox_->setMaximum(100000000);
-  density_value_spinbox_->setSingleStep(1000);
-  density_value_spinbox_->setEnabled(true);
-  slider_layout->addWidget(density_value_spinbox_);
-  changeDensity(density_slider_->value());  // initialize label with value
-  connect(density_value_spinbox_, SIGNAL(valueChanged(int)), this, SLOT(changeDensity(int)));
+  sample_spinbox_ = new QSpinBox(this);
+  sample_spinbox_->setMinimumWidth(70);
+  sample_spinbox_->setMinimum(1000);
+  sample_spinbox_->setMaximum(100000000);
+  sample_spinbox_->setSingleStep(1000);
+  sample_spinbox_->setEnabled(true);
+  slider_layout->addWidget(sample_spinbox_);
+  changeNumSamples(sample_slider_->value());  // initialize label with value
+  connect(sample_spinbox_, SIGNAL(valueChanged(int)), this, SLOT(changeNumSamples(int)));
 
   QHBoxLayout* buttons_layout = new QHBoxLayout();
   buttons_layout->setAlignment(Qt::AlignRight);
@@ -328,8 +328,8 @@ void DefaultCollisionsWidget::finishGeneratingCollisionTable()
 // ******************************************************************************************
 void DefaultCollisionsWidget::generateCollisionTable(unsigned int* collision_progress)
 {
-  unsigned int num_trials = (density_value_spinbox_->value() / 1000.0) * 1000;  // round the value in 1000s
-  num_trials = num_trials < 1000 ? 1000 : num_trials;                           // make sure that num_trials >= 1000
+  unsigned int num_trials = (sample_spinbox_->value() / 1000.0) * 1000;  // round the value in 1000s
+  num_trials = num_trials < 1000 ? 1000 : num_trials;                    // make sure that num_trials >= 1000
   double min_frac = (double)fraction_spinbox_->value() / 100.0;
 
   const bool verbose = true;  // Output benchmarking and statistics
@@ -708,22 +708,22 @@ void DefaultCollisionsWidget::toggleSelection(QItemSelection selection)
 }
 
 // ******************************************************************************************
-// GUI func for showing sampling density amount
+// GUI func for updating number of samples
 // ******************************************************************************************
-void DefaultCollisionsWidget::changeDensity(int value)
+void DefaultCollisionsWidget::changeNumSamples(int value)
 {
-  density_value_spinbox_->blockSignals(true);
-  density_slider_->blockSignals(true);
+  sample_spinbox_->blockSignals(true);
+  sample_slider_->blockSignals(true);
 
   int rounded_value = round(value / 1000.0) * 1000;
-  if (!density_value_spinbox_->hasFocus())
+  if (!sample_spinbox_->hasFocus())
   {
-    density_value_spinbox_->setValue(rounded_value);
+    sample_spinbox_->setValue(rounded_value);
   }
-  density_slider_->setValue(rounded_value);
+  sample_slider_->setValue(rounded_value);
 
-  density_value_spinbox_->blockSignals(false);
-  density_slider_->blockSignals(false);
+  sample_spinbox_->blockSignals(false);
+  sample_slider_->blockSignals(false);
 }
 
 // ******************************************************************************************

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.cpp
@@ -132,9 +132,9 @@ DefaultCollisionsWidget::DefaultCollisionsWidget(QWidget* parent, const MoveItCo
   density_slider_->setMinimum(1000);
   density_slider_->setMaximum(100000);
   density_slider_->setSingleStep(1000);
-  density_slider_->setPageStep(1000);
+  density_slider_->setPageStep(10000);
   density_slider_->setSliderPosition(10000);  // 10,000 is default
-  density_slider_->setTickInterval(1000);
+  density_slider_->setTickInterval(10000);
   density_slider_->setOrientation(Qt::Horizontal);
   slider_layout->addWidget(density_slider_);
   connect(density_slider_, SIGNAL(valueChanged(int)), this, SLOT(changeDensity(int)));

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -107,6 +107,10 @@ private Q_SLOTS:
    * \brief finish generating collision matrix after worker thread has finished
    */
   void finishGeneratingCollisionTable();
+  /**
+   * \brief interrupt generating collision matrix
+   */
+  void interruptGeneratingCollisionTable();
 
   /**
    * \brief GUI func for showing sampling density amount. Number of samples will be rounded in 1000s.
@@ -169,6 +173,7 @@ private:
   QPushButton* btn_generate_;
   QGroupBox* controls_box_;
   QProgressBar* progress_bar_;
+  QPushButton* btn_interrupt_;
   QLabel* progress_label_;
   QLineEdit* link_name_filter_;
   QCheckBox* collision_checkbox_;

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -109,16 +109,10 @@ private Q_SLOTS:
   void finishGeneratingCollisionTable();
 
   /**
-   * \brief GUI func for showing sampling density amount
-   * \param value Sampling density
-   */
-  void changeDensitySpinbox(int value);
-
-  /**
-   * \brief GUI func for showing sampling density amount
+   * \brief GUI func for showing sampling density amount. Number of samples will be rounded in 1000s.
    * \param value Number of samples
    */
-  void changeDensitySlider(int value);
+  void changeDensity(int value);
 
   /**
    * \brief Update view and data model for the link_pairs data structure

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -113,10 +113,10 @@ private Q_SLOTS:
   void interruptGeneratingCollisionTable();
 
   /**
-   * \brief GUI func for showing sampling density amount. Number of samples will be rounded in 1000s.
+   * \brief GUI func for showing number of samples. value will be rounded in 1000s.
    * \param value Number of samples
    */
-  void changeDensity(int value);
+  void changeNumSamples(int value);
 
   /**
    * \brief Update view and data model for the link_pairs data structure
@@ -168,8 +168,8 @@ private:
   QAbstractItemModel* model_;
   QItemSelectionModel* selection_model_;
   QVBoxLayout* layout_;
-  QSpinBox* density_value_spinbox_;
-  QSlider* density_slider_;
+  QSpinBox* sample_spinbox_;
+  QSlider* sample_slider_;
   QPushButton* btn_generate_;
   QGroupBox* controls_box_;
   QProgressBar* progress_bar_;

--- a/moveit_setup_assistant/src/widgets/default_collisions_widget.h
+++ b/moveit_setup_assistant/src/widgets/default_collisions_widget.h
@@ -45,6 +45,7 @@ class QHeaderView;
 class QItemSelection;
 class QItemSelectionModel;
 class QLabel;
+class QSpinBox;
 class QLineEdit;
 class QProgressBar;
 class QPushButton;
@@ -111,7 +112,13 @@ private Q_SLOTS:
    * \brief GUI func for showing sampling density amount
    * \param value Sampling density
    */
-  void changeDensityLabel(int value);
+  void changeDensitySpinbox(int value);
+
+  /**
+   * \brief GUI func for showing sampling density amount
+   * \param value Number of samples
+   */
+  void changeDensitySlider(int value);
 
   /**
    * \brief Update view and data model for the link_pairs data structure
@@ -163,7 +170,7 @@ private:
   QAbstractItemModel* model_;
   QItemSelectionModel* selection_model_;
   QVBoxLayout* layout_;
-  QLabel* density_value_label_;
+  QSpinBox* density_value_spinbox_;
   QSlider* density_slider_;
   QPushButton* btn_generate_;
   QGroupBox* controls_box_;


### PR DESCRIPTION
### Description

This PR solves #3526

- Replaced QLabel showing the number of samples with QSpinbox. Sampling spinbox and slider are connected to each other. Slider works in range (1.000-100.000), Spinbox works in range (1.000-100.000.000). Values are always rounded in 1000s. User can set high number of samples using Spinbox which may also increase the waiting time.
- Refactored the code to use the number of samples instead of density in the range 0-100.
- Added an interrupt button if the collision generation takes a long time for the user.
- Increased the progress bar update period from 5% to 1% but that caused Floating Point Exception somewhere in the code, so reverted the changes.

Default:
![default](https://github.com/ros-planning/moveit/assets/12991962/6e1ec3af-11b0-405f-9245-4958e31f6672)

Number of samples set to maximum using the spinbox and generating:
![computing](https://github.com/ros-planning/moveit/assets/12991962/d6ad49cb-dc76-4deb-8a19-845dae172866)

Clicked on the interrupt button:
![interrupt](https://github.com/ros-planning/moveit/assets/12991962/a3cd1177-7da8-4847-bc89-a9d40069d53b)

Experimented on [a two-arm robot configuration](https://github.com/RePAIRProject/repair_ros_robot) with different number of samples. I think setting the upper limit to 100.000.000 makes sense because setting to 10.000.000 doesn't create the same solution every time.

```
100.000:
[ INFO] [1699975705.184316444]:     33 : Total Links
[ INFO] [1699975705.184333485]:    528 : Total possible collisions
[ INFO] [1699975705.184345498]:      0 : Always in collision
[ INFO] [1699975705.184357999]:    317 : Never in collision
[ INFO] [1699975705.184368336]:     19 : Default in collision
[ INFO] [1699975705.184379440]:     28 : Adjacent links disabled
[ INFO] [1699975705.184390406]:    164 : Sometimes in collision
[ INFO] [1699975705.184399764]:    364 : TOTAL DISABLED

500.000:
[ INFO] [1699975740.059887924]:     33 : Total Links
[ INFO] [1699975740.059903708]:    528 : Total possible collisions
[ INFO] [1699975740.059915581]:      0 : Always in collision
[ INFO] [1699975740.059926686]:    316 : Never in collision
[ INFO] [1699975740.059938000]:     19 : Default in collision
[ INFO] [1699975740.059947987]:     28 : Adjacent links disabled
[ INFO] [1699975740.059958603]:    165 : Sometimes in collision
[ INFO] [1699975740.059968939]:    363 : TOTAL DISABLED

1.000.000:
[ INFO] [1699975767.495380743]:     33 : Total Links
[ INFO] [1699975767.495407213]:    528 : Total possible collisions
[ INFO] [1699975767.495424534]:      0 : Always in collision
[ INFO] [1699975767.495441994]:    313 : Never in collision
[ INFO] [1699975767.495458826]:     19 : Default in collision
[ INFO] [1699975767.495473981]:     28 : Adjacent links disabled
[ INFO] [1699975767.495490254]:    168 : Sometimes in collision
[ INFO] [1699975767.495505480]:    360 : TOTAL DISABLED

5.000.000:
[ INFO] [1699975834.433148867]:     33 : Total Links
[ INFO] [1699975834.433171705]:    528 : Total possible collisions
[ INFO] [1699975834.433191470]:      0 : Always in collision
[ INFO] [1699975834.433208023]:    306 : Never in collision
[ INFO] [1699975834.433223877]:     19 : Default in collision
[ INFO] [1699975834.433239381]:     28 : Adjacent links disabled
[ INFO] [1699975834.433256073]:    175 : Sometimes in collision
[ INFO] [1699975834.433269902]:    353 : TOTAL DISABLED

10.000.000:
[ INFO] [1699976001.606243521]:     33 : Total Links
[ INFO] [1699976001.606260982]:    528 : Total possible collisions
[ INFO] [1699976001.606272086]:      0 : Always in collision
[ INFO] [1699976001.606282074]:    304 : Never in collision
[ INFO] [1699976001.606292061]:     19 : Default in collision
[ INFO] [1699976001.606302118]:     28 : Adjacent links disabled
[ INFO] [1699976001.606311686]:    177 : Sometimes in collision
[ INFO] [1699976001.606322023]:    351 : TOTAL DISABLED

50.000.000:
[ INFO] [1699976373.608263528]:     33 : Total Links
[ INFO] [1699976373.608278754]:    528 : Total possible collisions
[ INFO] [1699976373.608292582]:      0 : Always in collision
[ INFO] [1699976373.608314512]:    304 : Never in collision
[ INFO] [1699976373.608330436]:     19 : Default in collision
[ INFO] [1699976373.608346918]:     28 : Adjacent links disabled
[ INFO] [1699976373.608363541]:    177 : Sometimes in collision
[ INFO] [1699976373.608380023]:    351 : TOTAL DISABLED

100.000.000:
[ INFO] [1699977117.672622957]:     33 : Total Links
[ INFO] [1699977117.672644818]:    528 : Total possible collisions
[ INFO] [1699977117.672664443]:      0 : Always in collision
[ INFO] [1699977117.672683579]:    304 : Never in collision
[ INFO] [1699977117.672695452]:     19 : Default in collision
[ INFO] [1699977117.672706347]:     28 : Adjacent links disabled
[ INFO] [1699977117.672715986]:    177 : Sometimes in collision
[ INFO] [1699977117.672724925]:    351 : TOTAL DISABLED
```

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
