### PR TITLE
Pass more distance information out from FCL collision check

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -141,44 +141,7 @@ struct CostSource
   }
 };
 
-/** \brief Representation of a collision checking result */
-struct CollisionResult
-{
-  CollisionResult() : collision(false), distance(std::numeric_limits<double>::max()), contact_count(0)
-  {
-  }
-  using ContactMap = std::map<std::pair<std::string, std::string>, std::vector<Contact> >;
-
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-  /** \brief Clear a previously stored result */
-  void clear()
-  {
-    collision = false;
-    distance = std::numeric_limits<double>::max();
-    contact_count = 0;
-    contacts.clear();
-    cost_sources.clear();
-  }
-
-  /** \brief Throttled warning printing the first collision pair, if any. All collisions are logged at DEBUG level */
-  void print() const;
-
-  /** \brief True if collision was found, false otherwise */
-  bool collision;
-
-  /** \brief Closest distance between two bodies */
-  double distance;
-
-  /** \brief Number of contacts returned */
-  std::size_t contact_count;
-
-  /** \brief A map returning the pairs of body ids in contact, plus their contact details */
-  ContactMap contacts;
-
-  /** \brief These are the individual cost sources when costs are computed */
-  std::set<CostSource> cost_sources;
-};
+struct CollisionResult;
 
 /** \brief Representation of a collision checking request */
 struct CollisionRequest
@@ -377,5 +340,48 @@ struct DistanceResult
     minimum_distance.clear();
     distances.clear();
   }
+};
+
+/** \brief Representation of a collision checking result */
+struct CollisionResult
+{
+  CollisionResult() : collision(false), distance(std::numeric_limits<double>::max()), contact_count(0)
+  {
+  }
+  using ContactMap = std::map<std::pair<std::string, std::string>, std::vector<Contact> >;
+
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /** \brief Clear a previously stored result */
+  void clear()
+  {
+    collision = false;
+    distance = std::numeric_limits<double>::max();
+    distance_result.clear();
+    contact_count = 0;
+    contacts.clear();
+    cost_sources.clear();
+  }
+
+  /** \brief Throttled warning printing the first collision pair, if any. All collisions are logged at DEBUG level */
+  void print() const;
+
+  /** \brief True if collision was found, false otherwise */
+  bool collision;
+
+  /** \brief Closest distance between two bodies */
+  double distance;
+
+  /** \brief Distance data for each link */
+  DistanceResult distance_result;
+
+  /** \brief Number of contacts returned */
+  std::size_t contact_count;
+
+  /** \brief A map returning the pairs of body ids in contact, plus their contact details */
+  ContactMap contacts;
+
+  /** \brief These are the individual cost sources when costs are computed */
+  std::set<CostSource> cost_sources;
 };
 }  // namespace collision_detection

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -273,6 +273,7 @@ void CollisionEnvFCL::checkSelfCollisionHelper(const CollisionRequest& req, Coll
     dreq.acm = acm;
     dreq.enableGroup(getRobotModel());
     distanceSelf(dreq, dres, state);
+    res.distance_result = dres;
     res.distance = dres.minimum_distance.distance;
   }
 }
@@ -326,6 +327,7 @@ void CollisionEnvFCL::checkRobotCollisionHelper(const CollisionRequest& req, Col
     dreq.acm = acm;
     dreq.enableGroup(getRobotModel());
     distanceRobot(dreq, dres, state);
+    res.distance_result = dres;
     res.distance = dres.minimum_distance.distance;
   }
 }


### PR DESCRIPTION
### Description

The `CollisionResult` struct doesn't capture some useful information from the FCL collision check. Particularly of interest to us is when calculating the distance to collision (available information today), we'd like to know the two link names that are closest to collision.

This PR adds the `DistanceResult` as part of the `CollisionResult` such that we can access this information, and more.
