### PR TITLE
support full scene updates mid-execution in PlanExecution

### DIFF
--- a/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/move_action_capability.cpp
@@ -154,7 +154,7 @@ void MoveGroupMoveAction::executeMoveCallbackPlanOnly(const moveit_msgs::MoveGro
 
   // lock the scene so that it does not modify the world representation while diff() is called
   planning_scene_monitor::LockedPlanningSceneRO lscene(context_->planning_scene_monitor_);
-  const planning_scene::PlanningSceneConstPtr& the_scene =
+  const planning_scene::PlanningSceneConstPtr the_scene =
       (moveit::core::isEmpty(goal->planning_options.planning_scene_diff)) ?
           static_cast<const planning_scene::PlanningSceneConstPtr&>(lscene) :
           lscene->diff(goal->planning_options.planning_scene_diff);
@@ -209,7 +209,7 @@ bool MoveGroupMoveAction::planUsingPlanningPipeline(const planning_interface::Mo
   planning_scene_monitor::LockedPlanningSceneRO lscene(plan.planning_scene_monitor_);
   try
   {
-    solved = planning_pipeline->generatePlan(plan.planning_scene_, req, res);
+    solved = planning_pipeline->generatePlan(plan.planning_scene_ ? plan.planning_scene_ : lscene, req, res);
   }
   catch (std::exception& ex)
   {


### PR DESCRIPTION
`plan.planning_scene_` was a trick to optionally apply a diff
on top of the scene maintained by `plan.planning_scene_monitor_`.

Everyday use does not rely on this additional diff.

This trick is severely flawed in multiple ways, e.g., changes to the `World`
of the monitored planning scene will not be noticed if a custom diff
is provided iff the diff includes changes to the world, because
`plan.planning_scene_` will provide its own world and the parent world
will never be looked at.

Crucially, if `plan.planning_scene_` was created as a `diff()` on top of
the scene of the monitor AND the monitor receives a full new scene AND
the monitor maintains diffs (the default in the `move_group` node),
`plan.planning_scene_.parent_` will point to `PlanningSceneMonitor::parent_scene_`
from then on and will thus not include the latest changes which are
maintained in `PlanningSceneMonitor::scene_`.
With the second full scene message, `plan.planning_scene_` will not get
any updates from the monitor anymore at all.

This patch changes the internal semantics of `plan.planning_scene_`
to override validation checks along the whole trajectory without
(deliberate) updates from the monitor.
On the other hand, if no diff is specified, the monitored scene will be
used everywhere, making changes in the monitored scene available to
validation checks everywhere.

Required to get the pickplace test in https://github.com/ros-planning/moveit_task_constructor/pull/432
to pass again with support for backward scene modifications.

@rhaschke That took a while...
