### PR TITLE
find links with slashes again

### DIFF
--- a/moveit_core/robot_state/CMakeLists.txt
+++ b/moveit_core/robot_state/CMakeLists.txt
@@ -23,7 +23,7 @@ if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
 
   catkin_add_gtest(test_robot_state test/robot_state_test.cpp)
-  target_link_libraries(test_robot_state ${MOVEIT_LIB_NAME} moveit_test_utils)
+  target_link_libraries(test_robot_state ${MOVEIT_LIB_NAME} moveit_test_utils gmock_main)
 
   catkin_add_gtest(test_planar_joint_jacobian test/test_planar_joint_jacobian.cpp)
   target_link_libraries(test_planar_joint_jacobian ${MOVEIT_LIB_NAME} moveit_test_utils)

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -233,179 +233,180 @@ class OneRobot : public testing::Test
 protected:
   void SetUp() override
   {
-    static const std::string MODEL2 =
-        "<?xml version=\"1.0\" ?>"
-        "<robot name=\"one_robot\">"
-        "<link name=\"base_link\">"
-        "  <inertial>"
-        "    <mass value=\"2.81\"/>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-        "  </inertial>"
-        "  <collision name=\"my_collision\">"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "<joint name=\"joint_a\" type=\"continuous\">"
-        "   <axis xyz=\"0 0 1\"/>"
-        "   <parent link=\"base_link\"/>"
-        "   <child link=\"link_a\"/>"
-        "   <origin rpy=\" 0.0 0 0 \" xyz=\"0.0 0 0 \"/>"
-        "</joint>"
-        "<link name=\"link_a\">"
-        "  <inertial>"
-        "    <mass value=\"1.0\"/>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-        "  </inertial>"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "<joint name=\"joint_b\" type=\"fixed\">"
-        "  <parent link=\"link_a\"/>"
-        "  <child link=\"link_b\"/>"
-        "  <origin rpy=\" 0.0 -0.42 0 \" xyz=\"0.0 0.5 0 \"/>"
-        "</joint>"
-        "<link name=\"link_b\">"
-        "  <inertial>"
-        "    <mass value=\"1.0\"/>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0.0 .0\"/>"
-        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-        "  </inertial>"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "  <joint name=\"joint_c\" type=\"prismatic\">"
-        "    <axis xyz=\"1 0 0\"/>"
-        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.09\" velocity=\"0.2\"/>"
-        "    <safety_controller k_position=\"20.0\" k_velocity=\"500.0\" soft_lower_limit=\"0.0\" "
-        "soft_upper_limit=\"0.089\"/>"
-        "    <parent link=\"link_b\"/>"
-        "    <child link=\"link_c\"/>"
-        "    <origin rpy=\" 0.0 0.42 0.0 \" xyz=\"0.0 -0.1 0 \"/>"
-        "  </joint>"
-        "<link name=\"link_c\">"
-        "  <inertial>"
-        "    <mass value=\"1.0\"/>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 .0\"/>"
-        "    <inertia ixx=\"0.1\" ixy=\"-0.2\" ixz=\"0.5\" iyy=\"-.09\" iyz=\"1\" izz=\"0.101\"/>"
-        "  </inertial>"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0.0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "  <joint name=\"mim_f\" type=\"prismatic\">"
-        "    <axis xyz=\"1 0 0\"/>"
-        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
-        "    <parent link=\"link_c\"/>"
-        "    <child link=\"link_d\"/>"
-        "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
-        "    <mimic joint=\"joint_f\" multiplier=\"1.5\" offset=\"0.1\"/>"
-        "  </joint>"
-        "  <joint name=\"joint_f\" type=\"prismatic\">"
-        "    <axis xyz=\"1 0 0\"/>"
-        "    <limit effort=\"100.0\" lower=\"0.0\" upper=\"0.19\" velocity=\"0.2\"/>"
-        "    <parent link=\"link_d\"/>"
-        "    <child link=\"link_e\"/>"
-        "    <origin rpy=\" 0.0 0.0 0.0 \" xyz=\"0.1 0.1 0 \"/>"
-        "  </joint>"
-        "<link name=\"link_d\">"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "<link name=\"link_e\">"
-        "  <collision>"
-        "    <origin rpy=\"0 0 0\" xyz=\"0 0 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </collision>"
-        "  <visual>"
-        "    <origin rpy=\"0 1 0\" xyz=\"0 0.1 0\"/>"
-        "    <geometry>"
-        "      <box size=\"1 2 1\" />"
-        "    </geometry>"
-        "  </visual>"
-        "</link>"
-        "</robot>";
-
-    static const std::string SMODEL2 =
-        "<?xml version=\"1.0\" ?>"
-        "<robot name=\"one_robot\">"
-        "<virtual_joint name=\"base_joint\" child_link=\"base_link\" parent_frame=\"odom_combined\" type=\"planar\"/>"
-        "<group name=\"base_from_joints\">"
-        "<joint name=\"base_joint\"/>"
-        "<joint name=\"joint_a\"/>"
-        "<joint name=\"joint_c\"/>"
-        "</group>"
-        "<group name=\"mim_joints\">"
-        "<joint name=\"joint_f\"/>"
-        "<joint name=\"mim_f\"/>"
-        "</group>"
-        "<group name=\"base_with_subgroups\">"
-        "<group name=\"base_from_base_to_tip\"/>"
-        "<joint name=\"joint_c\"/>"
-        "</group>"
-        "<group name=\"base_from_base_to_tip\">"
-        "<chain base_link=\"base_link\" tip_link=\"link_b\"/>"
-        "<joint name=\"base_joint\"/>"
-        "</group>"
-        "<group name=\"base_from_base_to_e\">"
-        "<chain base_link=\"base_link\" tip_link=\"link_e\"/>"
-        "<joint name=\"base_joint\"/>"
-        "</group>"
-        "<group name=\"base_with_bad_subgroups\">"
-        "<group name=\"error\"/>"
-        "</group>"
-        "</robot>";
+    static const std::string MODEL2 = R"(
+<?xml version="1.0" ?>
+<robot name="one_robot">
+<link name="base_link">
+  <inertial>
+    <mass value="2.81"/>
+    <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
+    <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
+  </inertial>
+  <collision name="my_collision">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 0 0" xyz="0.0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+<joint name="joint_a" type="continuous">
+   <axis xyz="0 0 1"/>
+   <parent link="base_link"/>
+   <child link="link_a"/>
+   <origin rpy=" 0.0 0 0 " xyz="0.0 0 0 "/>
+</joint>
+<link name="link_a">
+  <inertial>
+    <mass value="1.0"/>
+    <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
+    <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
+  </inertial>
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 0 0" xyz="0.0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+<joint name="joint_b" type="fixed">
+  <parent link="link_a"/>
+  <child link="link_b"/>
+  <origin rpy=" 0.0 -0.42 0 " xyz="0.0 0.5 0 "/>
+</joint>
+<link name="link_b">
+  <inertial>
+    <mass value="1.0"/>
+    <origin rpy="0 0 0" xyz="0.0 0.0 .0"/>
+    <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
+  </inertial>
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 0 0" xyz="0.0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+  <joint name="joint_c" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit effort="100.0" lower="0.0" upper="0.09" velocity="0.2"/>
+    <safety_controller k_position="20.0" k_velocity="500.0" soft_lower_limit="0.0"
+soft_upper_limit="0.089"/>
+    <parent link="link_b"/>
+    <child link="link_c"/>
+    <origin rpy=" 0.0 0.42 0.0 " xyz="0.0 -0.1 0 "/>
+  </joint>
+<link name="link_c">
+  <inertial>
+    <mass value="1.0"/>
+    <origin rpy="0 0 0" xyz="0.0 0 .0"/>
+    <inertia ixx="0.1" ixy="-0.2" ixz="0.5" iyy="-.09" iyz="1" izz="0.101"/>
+  </inertial>
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 0 0" xyz="0.0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+  <joint name="mim_f" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit effort="100.0" lower="0.0" upper="0.19" velocity="0.2"/>
+    <parent link="link_c"/>
+    <child link="link_d"/>
+    <origin rpy=" 0.0 0.0 0.0 " xyz="0.1 0.1 0 "/>
+    <mimic joint="joint_f" multiplier="1.5" offset="0.1"/>
+  </joint>
+  <joint name="joint_f" type="prismatic">
+    <axis xyz="1 0 0"/>
+    <limit effort="100.0" lower="0.0" upper="0.19" velocity="0.2"/>
+    <parent link="link_d"/>
+    <child link="link_e"/>
+    <origin rpy=" 0.0 0.0 0.0 " xyz="0.1 0.1 0 "/>
+  </joint>
+<link name="link_d">
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 1 0" xyz="0 0.1 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+<link name="link_e">
+  <collision>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </collision>
+  <visual>
+    <origin rpy="0 1 0" xyz="0 0.1 0"/>
+    <geometry>
+      <box size="1 2 1" />
+    </geometry>
+  </visual>
+</link>
+</robot>
+)";
+    static const std::string SMODEL2 = R"(
+<?xml version="1.0" ?>
+<robot name="one_robot">
+<virtual_joint name="base_joint" child_link="base_link" parent_frame="odom_combined" type="planar"/>
+<group name="base_from_joints">
+<joint name="base_joint"/>
+<joint name="joint_a"/>
+<joint name="joint_c"/>
+</group>
+<group name="mim_joints">
+<joint name="joint_f"/>
+<joint name="mim_f"/>
+</group>
+<group name="base_with_subgroups">
+<group name="base_from_base_to_tip"/>
+<joint name="joint_c"/>
+</group>
+<group name="base_from_base_to_tip">
+<chain base_link="base_link" tip_link="link_b"/>
+<joint name="base_joint"/>
+</group>
+<group name="base_from_base_to_e">
+<chain base_link="base_link" tip_link="link_e"/>
+<joint name="base_joint"/>
+</group>
+<group name="base_with_bad_subgroups">
+<group name="error"/>
+</group>
+</robot>
+)";
 
     urdf::ModelInterfaceSharedPtr urdf_model = urdf::parseURDF(MODEL2);
     srdf::ModelSharedPtr srdf_model = std::make_shared<srdf::Model>();

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -742,10 +742,12 @@ TEST_F(OneRobot, rigidlyConnectedParent)
 
   // the last /-separated component of an object might be a subframe
   state.attachBody(std::make_unique<moveit::core::AttachedBody>(
-      link_with_slash, "object", Eigen::Isometry3d(Eigen::Translation3d(1, 0, 0)), std::vector<shapes::ShapeConstPtr>{},
-      EigenSTL::vector_Isometry3d{}, std::set<std::string>{}, trajectory_msgs::JointTrajectory{},
-      moveit::core::FixedTransformsMap{ { "subframe", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)) } }));
-  const moveit::core::LinkModel* rigid_parent_of_object = state.getRigidlyConnectedParentLinkModel("object/subframe");
+      link_with_slash, "object/with/slash", Eigen::Isometry3d(Eigen::Translation3d(1, 0, 0)),
+      std::vector<shapes::ShapeConstPtr>{}, EigenSTL::vector_Isometry3d{}, std::set<std::string>{},
+      trajectory_msgs::JointTrajectory{},
+      moveit::core::FixedTransformsMap{ { "sub/frame", Eigen::Isometry3d(Eigen::Translation3d(0, 0, 1)) } }));
+  const moveit::core::LinkModel* rigid_parent_of_object =
+      state.getRigidlyConnectedParentLinkModel("object/with/slash/sub/frame");
   ASSERT_TRUE(rigid_parent_of_object);
   EXPECT_EQ(rigid_parent_of_link_with_slash, rigid_parent_of_object);
 }


### PR DESCRIPTION
fix link names with slashes when looking up rigid parents.

Since subframes were added, `RobotState::getRigidlyConnectedParentLinkModel` did not see links anymore if they contained slashes.

We can debate whether `object/subframe` should have priority as a world object with subframe or as a link/object name, but subframes are definitely rarer and we do not want to forbid '/' in link/object names (too late for that).
