### PR TITLE
Correctly initialize RobotState joint transforms for fixed joints

### DIFF
--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -133,7 +133,7 @@ void RobotState::initTransforms()
   for (size_t i = 0, end = robot_model_->getJointModelCount() + robot_model_->getLinkModelCount() +
                            robot_model_->getLinkGeometryCount();
        i != end; ++i)
-    variable_joint_transforms_[i] = Eigen::Isometry3d::Identity();
+    variable_joint_transforms_[i].setIdentity();
 }
 
 RobotState& RobotState::operator=(const RobotState& other)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -127,13 +127,16 @@ void RobotState::initTransforms()
       1 + robot_model_->getJointModelCount() / (sizeof(double) / sizeof(unsigned char));
   memset(dirty_joint_transforms_, 1, sizeof(double) * nr_doubles_for_dirty_joint_transforms);
 
-  // initialize all transforms to identity.
-  // The last row will not be modified by transform updates anymore, and the transforms for fixed
-  // joint won't be updated at all.
+  // initialize last row of transformation matrices, which will not be modified by transform updates anymore
   for (size_t i = 0, end = robot_model_->getJointModelCount() + robot_model_->getLinkModelCount() +
                            robot_model_->getLinkGeometryCount();
        i != end; ++i)
-    variable_joint_transforms_[i].setIdentity();
+    variable_joint_transforms_[i].makeAffine();
+
+  // Initialize fixed joints because they are not computed later by update().
+  for (const JointModel* joint : robot_model_->getJointModels())
+    if (joint->getType() == JointModel::FIXED)
+      getJointTransform(joint);
 }
 
 RobotState& RobotState::operator=(const RobotState& other)

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -2241,6 +2241,9 @@ void RobotState::printTransforms(std::ostream& out) const
   const std::vector<const JointModel*>& jm = robot_model_->getJointModels();
   for (const JointModel* joint : jm)
   {
+    if (joint->getType() == JointModel::FIXED)
+      continue;
+
     out << "  " << joint->getName();
     const int idx = joint->getJointIndex();
     if (dirty_joint_transforms_[idx])

--- a/moveit_core/robot_state/src/robot_state.cpp
+++ b/moveit_core/robot_state/src/robot_state.cpp
@@ -127,11 +127,13 @@ void RobotState::initTransforms()
       1 + robot_model_->getJointModelCount() / (sizeof(double) / sizeof(unsigned char));
   memset(dirty_joint_transforms_, 1, sizeof(double) * nr_doubles_for_dirty_joint_transforms);
 
-  // initialize last row of transformation matrices, which will not be modified by transform updates anymore
+  // initialize all transforms to identity.
+  // The last row will not be modified by transform updates anymore, and the transforms for fixed
+  // joint won't be updated at all.
   for (size_t i = 0, end = robot_model_->getJointModelCount() + robot_model_->getLinkModelCount() +
                            robot_model_->getLinkGeometryCount();
        i != end; ++i)
-    variable_joint_transforms_[i].makeAffine();
+    variable_joint_transforms_[i] = Eigen::Isometry3d::Identity();
 }
 
 RobotState& RobotState::operator=(const RobotState& other)

--- a/moveit_core/robot_state/test/robot_state_test.cpp
+++ b/moveit_core/robot_state/test/robot_state_test.cpp
@@ -184,7 +184,7 @@ TEST(LoadingAndFK, SimpleRobot)
 
 TEST(Init, FixedJoints)
 {
-  char const* const URDF = R"(
+  char const* const urdf_description = R"(
 <robot name="minibot">
     <link name="root"/>
     <link name="link1"/>
@@ -203,16 +203,16 @@ TEST(Init, FixedJoints)
 </robot>
 )";
 
-  char const* const SRDF = R"(
+  char const* const srdf_description = R"(
 <robot name="minibot">
     <virtual_joint name="world_to_root" type="fixed" parent_frame="world" child_link="root"/>
 </robot>
 )";
 
   auto urdf = std::make_shared<urdf::Model>();
-  ASSERT_TRUE(urdf->initString(URDF));
+  ASSERT_TRUE(urdf->initString(urdf_description));
   auto srdf = std::make_shared<srdf::Model>();
-  ASSERT_TRUE(srdf->initString(*urdf, SRDF));
+  ASSERT_TRUE(srdf->initString(*urdf, srdf_description));
   moveit::core::RobotModelConstPtr model = std::make_shared<moveit::core::RobotModel>(urdf, srdf);
   moveit::core::RobotState state{ model };
   state.setJointPositions("link1_joint", { 4.2 });


### PR DESCRIPTION
RobotState never updates the fixed joints transforms, thus reading unititalized memory in printTransforms.

It still prints `[dirty]` for the fixed joints but I don't think that's an issue.

Another way to fix it would be to remove the fixed joints optimization in `RobotState::updateLinkTransformsInternal`, but that's not worth the cost.

Closes #3540.

### Description

Please explain the changes you made, including a reference to the related issue if applicable

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
  - I could, but it involves a bit of complex code to pollute the heap, I don't think it's worth it.
- [ ] Include a screenshot if changing a GUI
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
