### PR TITLE
Update Dockerfile

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -16,8 +16,6 @@ COPY . src/moveit
 # Commands are combined in single RUN statement with "apt/lists" folder removal to reduce image size
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers
 RUN \
-    # Download ROS keys: https://github.com/osrf/docker_images/issues/697#issuecomment-1819626877
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA && \
     # Update apt package list as previous containers clear the cache
     apt-get -q update && \
     apt-get -q -y dist-upgrade && \


### PR DESCRIPTION
### Description
Adding the ROS key is done in the `ros:${ROS_DISTRO}-base` image that this image is built from (see PR [here](https://github.com/docker-library/official-images/pull/15809), and most recent image [here](https://hub.docker.com/layers/library/ros/melodic-ros-base/images/sha256-1db7d0292829a3612f4204ada9806052ca72490b36bd3bd9da0279d36d5fc7b2?context=explore))

Adding the key here is both redundant and [causes](https://github.com/ros-planning/moveit/actions/runs/7135007995/job/19430957106) [CI](https://github.com/ros-planning/moveit/actions/runs/7144540161/job/19458366833) [failures](https://github.com/ros-planning/moveit/actions/runs/7051621581/job/19194941114) as the keyserver can be unreliable. 