### PR TITLE
support new ompl cmake targets

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -27,26 +27,18 @@ else()
 endif()
 
 find_package(fcl QUIET)
-if (fcl_FOUND)
-  # convert cmake target to variables for catkin_package DEPENDS
-  if(TARGET ${FCL_LIBRARIES})
-    get_target_property(LIBFCL_LOCATION ${FCL_LIBRARIES} LOCATION)
-    get_target_property(LIBFCL_INTERFACE_LINK_LIBRARIES ${FCL_LIBRARIES} INTERFACE_LINK_LIBRARIES)
-    get_target_property(LIBFCL_INCLUDE_DIRS ${FCL_LIBRARIES} INTERFACE_INCLUDE_DIRECTORIES)
-    set(LIBFCL_LIBRARIES ${LIBFCL_LOCATION} ${LIBFCL_INTERFACE_LINK_LIBRARIES})
-  else()
-    set(LIBFCL_LIBRARIES ${FCL_LIBRARIES})
-    set(LIBFCL_INCLUDE_DIRS ${FCL_INCLUDE_DIRS})
-  endif()
-else()
+if (TARGET fcl)
+  moveit_get_include_and_libs_from_target(fcl fcl)
+elseif(NOT DEFINED fcl_FOUND OR NOT fcl_FOUND)
+  # Ubuntu 18.04 / fcl 0.5.0
   find_package(PkgConfig REQUIRED)
-  pkg_check_modules(LIBFCL_PC REQUIRED fcl)
-  set(LIBFCL_INCLUDE_DIRS ${LIBFCL_PC_INCLUDE_DIRS})
-  # find *absolute* paths to LIBFCL_LIBRARIES
-  set(LIBFCL_LIBRARIES)
-  foreach(_lib ${LIBFCL_PC_LIBRARIES})
-    find_library(_lib_${_lib} ${_lib} HINTS ${LIBFCL_PC_LIBRARY_DIRS})
-    list(APPEND LIBFCL_LIBRARIES ${_lib_${_lib}})
+  pkg_check_modules(fcl_PC REQUIRED fcl)
+  set(fcl_INCLUDE_DIRS ${fcl_PC_INCLUDE_DIRS})
+  # find *absolute* paths for fcl_LIBRARIES
+  set(fcl_LIBRARIES)
+  foreach(_lib ${fcl_PC_LIBRARIES})
+    find_library(_lib_${_lib} ${_lib} HINTS ${fcl_PC_LIBRARY_DIRS})
+    list(APPEND fcl_LIBRARIES ${_lib_${_lib}})
   endforeach()
 endif()
 
@@ -175,7 +167,7 @@ catkin_package(
   DEPENDS
     Boost
     EIGEN3
-    LIBFCL
+    fcl
     OCTOMAP
     ruckig
     urdfdom
@@ -195,7 +187,7 @@ include_directories(SYSTEM ${catkin_INCLUDE_DIRS}
                            ${EIGEN3_INCLUDE_DIRS}
                            ${urdfdom_INCLUDE_DIRS}
                            ${urdfdom_headers_INCLUDE_DIRS}
-                           ${LIBFCL_INCLUDE_DIRS}
+                           ${fcl_INCLUDE_DIRS}
                            ${BULLET_INCLUDE_DIRS}
                            ${OCTOMAP_INCLUDE_DIRS}
                     )

--- a/moveit_core/cmake/moveit.cmake
+++ b/moveit_core/cmake/moveit.cmake
@@ -26,3 +26,13 @@ macro(moveit_build_options)
     endif()
   endif()
 endmacro()
+
+# catkin_package DEPENDS does not consider INTERFACE_* of imported targets.
+# this macro makes them explicit in ${namespace}_INCLUDE_DIRS and ${namespace}_LIBRARIES
+# so that catkin-generated cmake files include them for downstream packages
+macro(moveit_get_include_and_libs_from_target namespace tgt)
+  get_target_property(${namespace}_INCLUDE_DIRS ${tgt} INTERFACE_INCLUDE_DIRECTORIES)
+
+  get_target_property(${namespace}_INTERFACE_LINK_LIBRARIES ${tgt} INTERFACE_LINK_LIBRARIES)
+  set(${namespace}_LIBRARIES ${tgt} ${${namespace}_INTERFACE_LINK_LIBRARIES})
+endmacro()

--- a/moveit_core/collision_detection_fcl/CMakeLists.txt
+++ b/moveit_core/collision_detection_fcl/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(${MOVEIT_LIB_NAME}
 set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 
 
-target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${LIBFCL_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_collision_detection ${catkin_LIBRARIES} ${urdfdom_LIBRARIES} ${urdfdom_headers_LIBRARIES} ${fcl_LIBRARIES} ${Boost_LIBRARIES})
 add_dependencies(${MOVEIT_LIB_NAME} ${catkin_EXPORTED_TARGETS})
 
 add_library(collision_detector_fcl_plugin src/collision_detector_fcl_plugin_loader.cpp)

--- a/moveit_planners/ompl/CMakeLists.txt
+++ b/moveit_planners/ompl/CMakeLists.txt
@@ -14,6 +14,9 @@ find_package(catkin REQUIRED COMPONENTS
 moveit_build_options()
 
 find_package(ompl REQUIRED)
+if(TARGET ompl::ompl)
+  moveit_get_include_and_libs_from_target(OMPL ompl::ompl)
+endif()
 
 generate_dynamic_reconfigure_options("ompl_interface/cfg/OMPLDynamicReconfigure.cfg")
 

--- a/moveit_setup_assistant/CMakeLists.txt
+++ b/moveit_setup_assistant/CMakeLists.txt
@@ -22,6 +22,10 @@ find_package(catkin REQUIRED COMPONENTS
 moveit_build_options()
 
 find_package(ompl REQUIRED)
+if(TARGET ompl::ompl)
+  moveit_get_include_and_libs_from_target(OMPL ompl::ompl)
+endif()
+
 include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${OMPL_INCLUDE_DIRS})
 include_directories(include)
 


### PR DESCRIPTION
ompl's main branch changed omplConfig.cmake changed from `OMPL_*` variables to imported targets via `ompl::ompl` in October 2023 and the moveit:master build breaks with it at the moment because of that.

I generalized the way we handled fcl when it did the same and cleaned up a bit.
