### PR TITLE
need to find pybind11_catkin earlier to avoid python3_add_library build error

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -56,6 +56,8 @@ find_package(urdfdom_headers REQUIRED)
 
 find_package(catkin REQUIRED
 COMPONENTS
+  # pybind needs to be found earlier in Ubuntu 22.04 and similar https://github.com/pybind/pybind11/issues/3996
+  pybind11_catkin
   tf2_eigen
   tf2_geometry_msgs
   eigen_stl_containers
@@ -76,7 +78,6 @@ COMPONENTS
   urdf
   visualization_msgs
   xmlrpcpp
-  pybind11_catkin
   pluginlib
   angles
 )


### PR DESCRIPTION

### Description

I get this error building on Ubuntu 23.10 (I assume it would also occur in 23.04 and maybe 22.04, I'll try those out with Docker):

```
CMake Error at /usr/lib/cmake/pybind11/pybind11NewTools.cmake:189 (python3_add_library):
  Unknown CMake command "python3_add_library".
```

The fix is to move pybind11_catkin up the list in find_package as suggested in https://github.com/pybind/pybind11/issues/3996#issuecomment-1689793861

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html) 

I could make a github action build this in 22.04 and/or 23.04

- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
