### PR TITLE
checkJointSpaceJump: use min instead of multiplication to combine relative and absolute check

### DIFF
--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -219,12 +219,14 @@ double CartesianInterpolator::checkJointSpaceJump(const JointModelGroup* group, 
     return percentage_solved;
 
   if (jump_threshold.factor > 0.0)
-    percentage_solved *= checkRelativeJointSpaceJump(group, traj, jump_threshold.factor);
+    percentage_solved = checkRelativeJointSpaceJump(group, traj, jump_threshold.factor);
 
+  double percentage_solved_absolute = 1.0;
   if (jump_threshold.revolute > 0.0 || jump_threshold.prismatic > 0.0)
-    percentage_solved *= checkAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
+    percentage_solved_absolute =
+        checkAbsoluteJointSpaceJump(group, traj, jump_threshold.revolute, jump_threshold.prismatic);
 
-  return percentage_solved;
+  return std::min(percentage_solved, percentage_solved_absolute);
 }
 
 double CartesianInterpolator::checkRelativeJointSpaceJump(const JointModelGroup* group,


### PR DESCRIPTION
### Description

the api suggests that you want to use either absolute or relative check in `CartesianInterpolator::checkJointSpaceJump` but does not enforce it (public parameters of JumpThreshold). If both are combined the minimum valid path should be returned instead of the product (which might be smaller if both checks trigger)
### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers
