### PR TITLE
MSA: Add missing filename attribute to gazebo plugin tag

### DIFF
--- a/moveit_setup_assistant/src/widgets/simulation_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/simulation_widget.cpp
@@ -311,7 +311,8 @@ std::string SimulationWidget::generateGazeboCompatibleURDF() const
 
   // Add gazebo_ros_control plugin which reads the transmission tags
   TiXmlElement* gazebo = uniqueInsert(*root, "gazebo");
-  TiXmlElement* plugin = uniqueInsert(*gazebo, "plugin", { { "name", "gazebo_ros_control", true } });
+  TiXmlElement* plugin = uniqueInsert(
+      *gazebo, "plugin", { { "name", "gazebo_ros_control", true }, { "filename", "libgazebo_ros_control.so", true } });
   uniqueInsert(*plugin, "robotNamespace", {}, "/");
 
   // generate new URDF


### PR DESCRIPTION
The Gazebo tags added by MSA where erroneous. The `gazebo/plugin` tag was missing the `filename` attribute:
```xml
    <gazebo>
        <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
            <robotNamespace>/</robotNamespace>
        </plugin>
    </gazebo>
```
This was causing the following error in Gazebo:
```
Error Code 4 Msg: Required attribute[filename] in element[plugin] is not specified in SDF.
Error Code 8 Msg: Error reading element <plugin>
Error Code 8 Msg: Error reading element <model>
Error Code 8 Msg: Error reading element <sdf>
```