### PR TITLE
Fixed some error in the doc string of compute_cartesian_path()

### DIFF
--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -652,7 +652,11 @@ class MoveGroupCommander(object):
         avoid_collisions=True,
         path_constraints=None,
     ):
-        """Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. Configurations are computed for every eef_step meters; The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath; Kinematic constraints for the path given by path_constraints will be met for every point along the trajectory, if they are not met, a partial solution will be returned. The return value is a tuple: a fraction of how much of the path was followed, the actual RobotTrajectory."""
+        """Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. 
+        Configurations are computed for every eef_step meters; 
+        The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath; 
+        Kinematic constraints for the path given by path_constraints will be met for every point along the trajectory, if they are not met, a partial solution will be returned. 
+        The return value is a tuple: the actual RobotTrajectory, a fraction of how much of the path was followed."""
         if path_constraints:
             if type(path_constraints) is Constraints:
                 constraints_str = conversions.msg_to_string(path_constraints)

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -655,7 +655,8 @@ class MoveGroupCommander(object):
         """Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. 
         Configurations are computed for every eef_step meters; 
         The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath; 
-        Kinematic constraints for the path given by path_constraints will be met for every point along the trajectory, if they are not met, a partial solution will be returned. 
+        Kinematic constraints for the path given by path_constraints will be met for every point along the trajectory.
+        If the Kinematic constraints are not met, a partial solution will be returned. 
         The return value is a tuple: the actual RobotTrajectory, a fraction of how much of the path was followed."""
         if path_constraints:
             if type(path_constraints) is Constraints:

--- a/moveit_commander/src/moveit_commander/move_group.py
+++ b/moveit_commander/src/moveit_commander/move_group.py
@@ -652,12 +652,13 @@ class MoveGroupCommander(object):
         avoid_collisions=True,
         path_constraints=None,
     ):
-        """Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints. 
-        Configurations are computed for every eef_step meters; 
-        The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath; 
+        """Compute a sequence of waypoints that make the end-effector move in straight line segments that follow the poses specified as waypoints.
+        Configurations are computed for every eef_step meters.
+        The jump_threshold specifies the maximum distance in configuration space between consecutive points in the resultingpath.
         Kinematic constraints for the path given by path_constraints will be met for every point along the trajectory.
-        If the Kinematic constraints are not met, a partial solution will be returned. 
-        The return value is a tuple: the actual RobotTrajectory, a fraction of how much of the path was followed."""
+        If the Kinematic constraints are not met, a partial solution will be returned.
+        The return value is a tuple: the actual RobotTrajectory and the fraction of how much of the path was followed.
+        """
         if path_constraints:
             if type(path_constraints) is Constraints:
                 constraints_str = conversions.msg_to_string(path_constraints)


### PR DESCRIPTION
### Description

The doc string in moveit_commander/move_group.py/compute_cartesian_path() has an error where the return values of the function are reversed. Also, I added some line breaks so it's more readable on the web-based documentation.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
