### PR TITLE
Allow waiting for joint model group states and retrieval of group-specific timestamps

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -232,6 +232,10 @@ public:
   }
 
 private:
+  /**
+   * Lock-free method that is used by @ref getCurrentStateTime and @ref getCurrentStateAndTime methods.
+   */
+  ros::Time getCurrentStateTimeHelper(const std::string& group = "") const;
   std::vector<std::string> haveCompleteStateHelper(const ros::Time& oldest_allowed_update_time,
                                                    const std::string& group) const;
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -156,12 +156,21 @@ public:
   /** @brief Set the state \e upd to the current state maintained by this class. */
   void setToCurrentState(moveit::core::RobotState& upd) const;
 
-  /** @brief Get the time stamp for the current state */
-  ros::Time getCurrentStateTime() const;
+  /** @brief Get the time stamp for the current state
+   *  @param group The name of the joint group whose current state is asked, defaults to empty string, which means all
+   * the active joints.
+   *  @note If there are multiple joint sources, then the oldest joint's timestamp is retrieved for the particular group
+   *  @return The current state timestamp related with group
+   */
+  ros::Time getCurrentStateTime(const std::string& group = "") const;
 
   /** @brief Get the current state and its time stamp
+   *  @param group The name of the joint group whose current state is asked, defaults to empty string, which means all
+   * the active joints.
+   *  @note If there are multiple sources of the constituent joints, then the oldest joint's timestamp is retrieved for
+   * the particular group
    *  @return Returns a pair of the current state and its time stamp */
-  std::pair<moveit::core::RobotStatePtr, ros::Time> getCurrentStateAndTime() const;
+  std::pair<moveit::core::RobotStatePtr, ros::Time> getCurrentStateAndTime(const std::string& group = "") const;
 
   /** @brief Get the current state values as a map from joint names to joint state values
    *  @return Returns the map from joint names to joint state values*/
@@ -235,7 +244,6 @@ private:
   ros::Time monitor_start_time_;
   double error_;
   ros::Subscriber joint_state_subscriber_;
-  ros::Time current_state_time_;
 
   mutable boost::mutex state_update_lock_;
   mutable boost::condition_variable state_update_condition_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -98,7 +98,7 @@ public:
    */
   inline bool haveCompleteState(const std::string& group = "") const
   {
-    return haveCompleteStateHelper(ros::Time(0), group).empty();
+    return haveCompleteStateHelper(ros::Time(0), nullptr, group);
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
@@ -107,7 +107,7 @@ public:
    *  information is more than \e age old*/
   inline bool haveCompleteState(const ros::Time& oldest_allowed_update_time, const std::string& group = "") const
   {
-    return haveCompleteStateHelper(oldest_allowed_update_time, group).empty();
+    return haveCompleteStateHelper(oldest_allowed_update_time, nullptr, group);
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
@@ -117,7 +117,7 @@ public:
    */
   inline bool haveCompleteState(const ros::Duration& age, const std::string& group = "") const
   {
-    return haveCompleteStateHelper(ros::Time::now() - age, group).empty();
+    return haveCompleteStateHelper(ros::Time::now() - age, nullptr, group);
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
@@ -126,8 +126,7 @@ public:
    */
   inline bool haveCompleteState(std::vector<std::string>& missing_joints, const std::string& group = "") const
   {
-    missing_joints = haveCompleteStateHelper(ros::Time(0), group);
-    return missing_joints.empty();
+    return haveCompleteStateHelper(ros::Time(0), &missing_joints, group);
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
@@ -138,8 +137,7 @@ public:
   inline bool haveCompleteState(const ros::Time& oldest_allowed_update_time, std::vector<std::string>& missing_joints,
                                 const std::string& group = "") const
   {
-    missing_joints = haveCompleteStateHelper(oldest_allowed_update_time, group);
-    return missing_joints.empty();
+    return haveCompleteStateHelper(oldest_allowed_update_time, &missing_joints, group);
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
@@ -149,8 +147,7 @@ public:
   inline bool haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints,
                                 const std::string& group = "") const
   {
-    missing_joints = haveCompleteStateHelper(ros::Time::now() - age, group);
-    return missing_joints.empty();
+    return haveCompleteStateHelper(ros::Time::now() - age, &missing_joints, group);
   }
 
   /** @brief Get the current state
@@ -236,8 +233,8 @@ private:
    * Lock-free method that is used by @ref getCurrentStateTime and @ref getCurrentStateAndTime methods.
    */
   ros::Time getCurrentStateTimeHelper(const std::string& group = "") const;
-  std::vector<std::string> haveCompleteStateHelper(const ros::Time& oldest_allowed_update_time,
-                                                   const std::string& group) const;
+  bool haveCompleteStateHelper(const ros::Time& oldest_allowed_update_time, std::vector<std::string>* missing_joints,
+                               const std::string& group) const;
 
   void jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state);
   void tfCallback();

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -96,18 +96,18 @@ public:
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @return False if we have no joint state information for one or more of the joints
    */
-  inline bool haveCompleteState() const
+  inline bool haveCompleteState(const std::string& group = "") const
   {
-    return haveCompleteStateHelper(ros::Time(0), nullptr);
+    return haveCompleteStateHelper(ros::Time(0), group).empty();
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @param oldest_allowed_update_time All joint information must be from this time or more current
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old*/
-  inline bool haveCompleteState(const ros::Time& oldest_allowed_update_time) const
+  inline bool haveCompleteState(const ros::Time& oldest_allowed_update_time, const std::string& group = "") const
   {
-    return haveCompleteStateHelper(oldest_allowed_update_time, nullptr);
+    return haveCompleteStateHelper(oldest_allowed_update_time, group).empty();
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
@@ -115,18 +115,19 @@ public:
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old
    */
-  inline bool haveCompleteState(const ros::Duration& age) const
+  inline bool haveCompleteState(const ros::Duration& age, const std::string& group = "") const
   {
-    return haveCompleteStateHelper(ros::Time::now() - age, nullptr);
+    return haveCompleteStateHelper(ros::Time::now() - age, group).empty();
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @param missing_joints Returns the list of joints that are missing
    *  @return False if we have no joint state information for one or more of the joints
    */
-  inline bool haveCompleteState(std::vector<std::string>& missing_joints) const
+  inline bool haveCompleteState(std::vector<std::string>& missing_joints, const std::string& group = "") const
   {
-    return haveCompleteStateHelper(ros::Time(0), &missing_joints);
+    missing_joints = haveCompleteStateHelper(ros::Time(0), group);
+    return missing_joints.empty();
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
@@ -134,19 +135,22 @@ public:
    *  @param missing_joints Returns the list of joints that are missing
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old*/
-  inline bool haveCompleteState(const ros::Time& oldest_allowed_update_time,
-                                std::vector<std::string>& missing_joints) const
+  inline bool haveCompleteState(const ros::Time& oldest_allowed_update_time, std::vector<std::string>& missing_joints,
+                                const std::string& group = "") const
   {
-    return haveCompleteStateHelper(oldest_allowed_update_time, &missing_joints);
+    missing_joints = haveCompleteStateHelper(oldest_allowed_update_time, group);
+    return missing_joints.empty();
   }
 
   /** @brief Query whether we have joint state information for all DOFs in the kinematic model
    *  @return False if we have no joint state information for one of the joints or if our state
    *  information is more than \e age old
    */
-  inline bool haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints) const
+  inline bool haveCompleteState(const ros::Duration& age, std::vector<std::string>& missing_joints,
+                                const std::string& group = "") const
   {
-    return haveCompleteStateHelper(ros::Time::now() - age, &missing_joints);
+    missing_joints = haveCompleteStateHelper(ros::Time::now() - age, group);
+    return missing_joints.empty();
   }
 
   /** @brief Get the current state
@@ -228,8 +232,8 @@ public:
   }
 
 private:
-  bool haveCompleteStateHelper(const ros::Time& oldest_allowed_update_time,
-                               std::vector<std::string>* missing_joints) const;
+  std::vector<std::string> haveCompleteStateHelper(const ros::Time& oldest_allowed_update_time,
+                                                   const std::string& group) const;
 
   void jointStateCallback(const sensor_msgs::JointStateConstPtr& joint_state);
   void tfCallback();

--- a/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_test.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_test.cpp
@@ -126,8 +126,6 @@ TEST_F(CurrentStateMonitorTest, CompleteStateTest)
   sendJointStateAndWait(js_a);
 
   EXPECT_FALSE(csm->haveCompleteState());
-  const double kTooLongWaitDurationInSeconds = 30000;
-  EXPECT_TRUE(csm->waitForCompleteState("group_a", 30000));
 
   sendJointStateAndWait(js_ab);
 
@@ -192,12 +190,11 @@ TEST_F(CurrentStateMonitorTest, NonMonotonicTimeStampsDueToPartialJoints)
       << "older partial joint state was ignored in current state retrieval!";
   EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime("group_a"))
       << "Group is aware of the timestamp of non-group joints!";
-    
+
   sendJointStateAndWait(js_b_t2);
   EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime())
       << "older partial joint state was ignored in current state retrieval!";
 }
-
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_test.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_test.cpp
@@ -126,6 +126,8 @@ TEST_F(CurrentStateMonitorTest, CompleteStateTest)
   sendJointStateAndWait(js_a);
 
   EXPECT_FALSE(csm->haveCompleteState());
+  const double kTooLongWaitDurationInSeconds = 30000;
+  EXPECT_TRUE(csm->waitForCompleteState("group_a", 30000));
 
   sendJointStateAndWait(js_ab);
 

--- a/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_test.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_test.cpp
@@ -147,11 +147,22 @@ TEST_F(CurrentStateMonitorTest, StateUpdateTest)
 
 TEST_F(CurrentStateMonitorTest, IncrementalTimeStamps)
 {
-  sendJointStateAndWait(js_a);
-  EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime());
+  sensor_msgs::JointState js_b_new;
+  js_b_new.name = { "b-c-joint" };
+  js_b_new.position = { 0.25 };
+  js_b_new.velocity = { 0.25 };
+  js_b_new.header.stamp = ros::Time{ 10.5 };
 
   sendJointStateAndWait(js_b);
-  EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime()) << "older stamp made csm jump backwards in time";
+  EXPECT_EQ(js_b.header.stamp, csm->getCurrentStateTime());
+
+  sendJointStateAndWait(js_a);
+  EXPECT_EQ(js_b.header.stamp, csm->getCurrentStateTime())
+      << "older partial joint state was ignored in current state retrieval!";
+
+  sendJointStateAndWait(js_b_new);
+  EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime())
+      << "older partial joint state was ignored in current state retrieval!";
 
   sendJointStateAndWait(js_ab);
   EXPECT_EQ(js_ab.header.stamp, csm->getCurrentStateTime()) << "newer stamp did not update csm";
@@ -164,6 +175,29 @@ TEST_F(CurrentStateMonitorTest, IncrementalTimeStamps)
       << "jumping back for a known joint did not reset state time";
   EXPECT_EQ(js_a_old.position[0], csm->getCurrentState()->getVariablePosition("a-b-joint"));
 }
+
+TEST_F(CurrentStateMonitorTest, NonMonotonicTimeStampsDueToPartialJoints)
+{
+  sensor_msgs::JointState js_b_t2;
+  js_b_t2.name = { "b-c-joint" };
+  js_b_t2.position = { 0.25 };
+  js_b_t2.velocity = { 0.25 };
+  js_b_t2.header.stamp = ros::Time{ 13.0 };
+
+  sendJointStateAndWait(js_a);
+  EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime());
+
+  sendJointStateAndWait(js_b);
+  EXPECT_EQ(js_b.header.stamp, csm->getCurrentStateTime())
+      << "older partial joint state was ignored in current state retrieval!";
+  EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime("group_a"))
+      << "Group is aware of the timestamp of non-group joints!";
+    
+  sendJointStateAndWait(js_b_t2);
+  EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime())
+      << "older partial joint state was ignored in current state retrieval!";
+}
+
 
 int main(int argc, char** argv)
 {

--- a/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_test.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/test/current_state_monitor_test.cpp
@@ -145,20 +145,16 @@ TEST_F(CurrentStateMonitorTest, StateUpdateTest)
 
 TEST_F(CurrentStateMonitorTest, IncrementalTimeStamps)
 {
-  sensor_msgs::JointState js_b_new;
-  js_b_new.name = { "b-c-joint" };
-  js_b_new.position = { 0.25 };
-  js_b_new.velocity = { 0.25 };
-  js_b_new.header.stamp = ros::Time{ 10.5 };
+  sendJointStateAndWait(js_a);
+  EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime());
 
   sendJointStateAndWait(js_b);
-  EXPECT_EQ(js_b.header.stamp, csm->getCurrentStateTime());
-
-  sendJointStateAndWait(js_a);
   EXPECT_EQ(js_b.header.stamp, csm->getCurrentStateTime())
       << "older partial joint state was ignored in current state retrieval!";
 
-  sendJointStateAndWait(js_b_new);
+  js_b.position = { 0.25 };
+  js_b.header.stamp = ros::Time{ 10.5 };
+  sendJointStateAndWait(js_b);
   EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime())
       << "older partial joint state was ignored in current state retrieval!";
 
@@ -176,12 +172,6 @@ TEST_F(CurrentStateMonitorTest, IncrementalTimeStamps)
 
 TEST_F(CurrentStateMonitorTest, NonMonotonicTimeStampsDueToPartialJoints)
 {
-  sensor_msgs::JointState js_b_t2;
-  js_b_t2.name = { "b-c-joint" };
-  js_b_t2.position = { 0.25 };
-  js_b_t2.velocity = { 0.25 };
-  js_b_t2.header.stamp = ros::Time{ 13.0 };
-
   sendJointStateAndWait(js_a);
   EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime());
 
@@ -191,7 +181,9 @@ TEST_F(CurrentStateMonitorTest, NonMonotonicTimeStampsDueToPartialJoints)
   EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime("group_a"))
       << "Group is aware of the timestamp of non-group joints!";
 
-  sendJointStateAndWait(js_b_t2);
+  js_b.position = { 0.25 };
+  js_b.header.stamp = ros::Time{ 13.0 };
+  sendJointStateAndWait(js_b);
   EXPECT_EQ(js_a.header.stamp, csm->getCurrentStateTime())
       << "older partial joint state was ignored in current state retrieval!";
 }


### PR DESCRIPTION
### Description
There are two main changes introduced by this PR that share the same core principle -- that is group-specific state monitoring capability.

I found https://github.com/ros-planning/moveit/issues/722 as the most relevant issue to target. This PR introduces: 

1. per-group current state time retrieval
2. per-group complete robot state waiting 

For 2, read the following scenario. I want to call `waitForCompleteState` on `group_A`, which the API already supports. There is also another joint `out_of_group_A` in the `robot_model_` that is not available until a certain time since the bringup. I'm making `waitForCompleteState(group_A, <timeout>)` way earlier than `out_of_group_A` is published by its source. The problem with the current implementation is that it waits until `<timeout>` elapses, but returns true since all joints of `group_A` exists. I don't see a point in waiting for an out-of-group joint with this API.

_A supplementary reason why I think https://github.com/ros-planning/moveit/issues/722 is relevant for both changes introduced by this PR is [this commit](https://github.com/ros-planning/moveit/commit/304f187cb33bc612af8d92c700b6f6af1390faeb). The renaming suggests that the methods of interest are now waitForCompleteState, which this PR mainly targets._
### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
