### PR TITLE
Fix warehouse database destruction

### DIFF
--- a/moveit_ros/warehouse/warehouse/src/broadcast.cpp
+++ b/moveit_ros/warehouse/warehouse/src/broadcast.cpp
@@ -37,6 +37,7 @@
 #include <moveit/warehouse/planning_scene_storage.h>
 #include <moveit/warehouse/constraints_storage.h>
 #include <moveit/warehouse/state_storage.h>
+#include <warehouse_ros/database_loader.h>
 
 #include <boost/program_options/cmdline.hpp>
 #include <boost/program_options/options_description.hpp>
@@ -92,7 +93,8 @@ int main(int argc, char** argv)
     return 2;
   }
   // Set up db
-  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/broadcast.cpp
+++ b/moveit_ros/warehouse/warehouse/src/broadcast.cpp
@@ -93,8 +93,8 @@ int main(int argc, char** argv)
     return 2;
   }
   // Set up db
-  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
-  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
+  auto db_loader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = db_loader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -224,8 +224,8 @@ int main(int argc, char** argv)
     return 1;
   }
   // Set up db
-  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
-  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
+  auto db_loader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = db_loader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/import_from_text.cpp
@@ -45,6 +45,7 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <warehouse_ros/database_loader.h>
 #include <ros/ros.h>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
@@ -223,7 +224,8 @@ int main(int argc, char** argv)
     return 1;
   }
   // Set up db
-  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
+++ b/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
@@ -71,8 +71,8 @@ int main(int argc, char** argv)
     return 1;
   }
   // Set up db
-  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
-  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
+  auto db_loader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = db_loader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
+++ b/moveit_ros/warehouse/warehouse/src/initialize_demo_db.cpp
@@ -40,6 +40,7 @@
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit/kinematic_constraints/utils.h>
+#include <warehouse_ros/database_loader.h>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/program_options/cmdline.hpp>
 #include <boost/program_options/options_description.hpp>
@@ -70,7 +71,8 @@ int main(int argc, char** argv)
     return 1;
   }
   // Set up db
-  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/moveit_message_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/moveit_message_storage.cpp
@@ -63,10 +63,10 @@ void moveit_warehouse::MoveItMessageStorage::filterNames(const std::string& rege
 
 typename warehouse_ros::DatabaseConnection::Ptr moveit_warehouse::loadDatabase()
 {
-  static std::unique_ptr<warehouse_ros::DatabaseLoader> DBLOADER;
-  if (!DBLOADER)
+  static std::unique_ptr<warehouse_ros::DatabaseLoader> db_loader;
+  if (!db_loader)
   {
-    DBLOADER = std::make_unique<warehouse_ros::DatabaseLoader>();
+    db_loader = std::make_unique<warehouse_ros::DatabaseLoader>();
   }
-  return DBLOADER->loadDatabase();
+  return db_loader->loadDatabase();
 }

--- a/moveit_ros/warehouse/warehouse/src/moveit_message_storage.cpp
+++ b/moveit_ros/warehouse/warehouse/src/moveit_message_storage.cpp
@@ -61,14 +61,12 @@ void moveit_warehouse::MoveItMessageStorage::filterNames(const std::string& rege
   }
 }
 
-static std::unique_ptr<warehouse_ros::DatabaseLoader> DBLOADER;
-
 typename warehouse_ros::DatabaseConnection::Ptr moveit_warehouse::loadDatabase()
 {
+  static std::unique_ptr<warehouse_ros::DatabaseLoader> DBLOADER;
   if (!DBLOADER)
   {
     DBLOADER = std::make_unique<warehouse_ros::DatabaseLoader>();
   }
   return DBLOADER->loadDatabase();
-  // return typename warehouse_ros::DatabaseConnection::Ptr(new warehouse_ros_mongo::MongoDatabaseConnection());
 }

--- a/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
@@ -95,8 +95,8 @@ int main(int argc, char** argv)
     return 1;
   }
   // Set up db
-  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
-  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
+  auto db_loader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = db_loader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_as_text.cpp
@@ -43,6 +43,7 @@
 #include <boost/program_options/variables_map.hpp>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/robot_state/conversions.h>
+#include <warehouse_ros/database_loader.h>
 #include <ros/ros.h>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
@@ -94,7 +95,8 @@ int main(int argc, char** argv)
     return 1;
   }
   // Set up db
-  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
@@ -133,8 +133,8 @@ int main(int argc, char** argv)
     return 1;
   }
   // Set up db
-  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
-  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
+  auto db_loader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = db_loader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
+++ b/moveit_ros/warehouse/warehouse/src/save_to_warehouse.cpp
@@ -45,6 +45,7 @@
 #include <boost/program_options/variables_map.hpp>
 #include <ros/ros.h>
 #include <tf2_ros/transform_listener.h>
+#include <warehouse_ros/database_loader.h>
 
 static const std::string ROBOT_DESCRIPTION = "robot_description";
 
@@ -132,7 +133,8 @@ int main(int argc, char** argv)
     return 1;
   }
   // Set up db
-  warehouse_ros::DatabaseConnection::Ptr conn = moveit_warehouse::loadDatabase();
+  auto dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
+  warehouse_ros::DatabaseConnection::Ptr conn = dbLoader->loadDatabase();
   if (vm.count("host") && vm.count("port"))
     conn->setParams(vm["host"].as<std::string>(), vm["port"].as<std::size_t>());
   if (!conn->connect())

--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -35,6 +35,7 @@
 /* Author: Dan Greenwald */
 
 #include <ros/ros.h>
+#include <warehouse_ros/database_loader.h>
 #include <moveit/warehouse/state_storage.h>
 #include <moveit_msgs/SaveRobotStateToWarehouse.h>
 #include <moveit_msgs/ListRobotStatesInWarehouse.h>
@@ -150,11 +151,13 @@ int main(int argc, char** argv)
   node.param<float>("warehouse_db_connection_timeout", connection_timeout, 5.0);
   node.param<int>("warehouse_db_connection_retries", connection_retries, 5);
 
+  std::unique_ptr<warehouse_ros::DatabaseLoader> dbLoader;
   warehouse_ros::DatabaseConnection::Ptr conn;
 
   try
   {
-    conn = moveit_warehouse::loadDatabase();
+    dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
+    conn = dbLoader->loadDatabase();
     conn->setParams(host, port, connection_timeout);
 
     ROS_INFO("Connecting to warehouse on %s:%d", host.c_str(), port);

--- a/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
+++ b/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp
@@ -151,13 +151,13 @@ int main(int argc, char** argv)
   node.param<float>("warehouse_db_connection_timeout", connection_timeout, 5.0);
   node.param<int>("warehouse_db_connection_retries", connection_retries, 5);
 
-  std::unique_ptr<warehouse_ros::DatabaseLoader> dbLoader;
+  std::unique_ptr<warehouse_ros::DatabaseLoader> db_loader;
   warehouse_ros::DatabaseConnection::Ptr conn;
 
   try
   {
-    dbLoader = std::make_unique<warehouse_ros::DatabaseLoader>();
-    conn = dbLoader->loadDatabase();
+    db_loader = std::make_unique<warehouse_ros::DatabaseLoader>();
+    conn = db_loader->loadDatabase();
     conn->setParams(host, port, connection_timeout);
 
     ROS_INFO("Connecting to warehouse on %s:%d", host.c_str(), port);


### PR DESCRIPTION
Standalone applications used the convenience function moveit_warehouse::loadDatabase() to load a database plugin. Internally, this uses a static plugin loader. As this static variable is released too late during app shutdown, we get an exception:

```
terminate called after throwing an instance of 'class_loader::LibraryUnloadException'
what():  Attempt to unload library that class_loader is unaware of.
```

Explicitly instantiating the loader ensures correct destruction order and avoids the error.

Interestingly, the MotionPlanning plugin, using the same function, doesn't exhibit that issue. Maybe, because it is itself a plugin and unloading it also unloads the corresponding database loader - in correct order.