### PR TITLE
Removes slow robotStateMsgToRobotState call from pilz

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator.cpp
@@ -352,7 +352,8 @@ TrajectoryGenerator::MotionPlanInfo::MotionPlanInfo(const planning_scene::Planni
   start_scene = std::move(scene->diff());
   auto jmg = start_scene->getCurrentState().getRobotModel()->getJointModelGroup(req.group_name);
   // initialize info.start_joint_position with active joint values from start_state
-  for (const auto* jm : jmg->getActiveJointModels()) {
+  for (const auto* jm : jmg->getActiveJointModels())
+  {
     const auto& names = jm->getVariableNames();
     for (std::size_t i = 0, j = jm->getFirstVariableIndex(); i < jm->getVariableCount(); ++i, ++j)
       start_joint_position[names[i]] = req.start_state.joint_state.position[j];


### PR DESCRIPTION
### Description

I've been spending some time profiling our motion planning pipeline, which has become quite slow recently.

Using a collision object we use to generate raster paths (~66k faces), and a path of ~400 cartestian points, we were achieving planning times of  ~30s.

I did some profiling of our own code, and found that around half the time was spent converting from `moveit_msgs::RobotState` to `moveit::core::RobotState` via `movit::core::robotStateMsgToRobotState()` for every point in our path. I suspect the main bottleneck was converting all of the attachment bodies (and their meshes). Rewriting the code to perform this conversion once at the start of path generation has reduced the time to ~30s, which appears to be spent mainly on the MoveIt side.

Of this remaining 30s, 23s are spent within pilz's `TrajectoryGenerator::generate()` in the `MotionPlanInfo` constructor, which, again, spends the majority of its time calling `moveit::core::robotStateMsgToRobotState()`.

**Time analysis of `TrajectoryGenerator::generate()` (Data & Pandas Summary)**

[TrajectoryGenerator__generate.csv](https://github.com/ros-planning/moveit/files/15036899/TrajectoryGenerator__generate.csv)
![trajectory_generate_before](https://github.com/ros-planning/moveit/assets/86778266/215f6378-0144-48ad-a485-662d116bceda)

**Time analysis of `MotionPlanInfo::MotionPlanInfo()` (Data & Pandas Summary)**

[MotionPlanInfo__MotionPlanInfo.csv](https://github.com/ros-planning/moveit/files/15036894/MotionPlanInfo__MotionPlanInfo.csv)
![motion_plan_info_before](https://github.com/ros-planning/moveit/assets/86778266/9297b278-b293-4bd9-8e7f-14c31d9108ef)


In my understanding, the purpose of the constructor is to set the `start_scene` and `start_joint_position` fields of this class. I've rewritten the implementation to take these values from the `MotionPlanRequest` parameter, rather than converting. Doing so has reduced the time spent in `TrajectoryGenerator::generate()` from ~23s to ~0.5s.

**New time analysis of `TrajectoryGenerator::generate()` (Data & Pandas Summary)**

[TrajectoryGenerator::generate.csv](https://github.com/ros-planning/moveit/files/15037344/TrajectoryGenerator.generate.csv)
![trajectory_generate_after](https://github.com/ros-planning/moveit/assets/86778266/dd9b1343-ab00-489a-8ea8-5e43a08bf018)


Since only the `start_scene`, which is const, and `start_joint_position` are set in this constructor, the resulting `MotionPlanInfo` should be unaffected by the changes. 

My only concern is whether the (now removed) call to `moveit::core::RobotState::update` may be having side effects beyond the scope of the method.

I'd appreciate any thoughts and suggestions regarding this change,

Tom



### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/) ( No user-facing changes )
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes (No API changes)
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [x] Include a screenshot if changing a GUI (No GUI changes. Profiling reports provided)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
