### PR TITLE
Disables copying of attached collision objects when updating start state

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
@@ -172,7 +172,7 @@ void CommandListManager::setStartState(const MotionResponseCont& motion_plan_res
   RobotState_OptRef rob_state_op{ getPreviousEndState(motion_plan_responses, group_name) };
   if (rob_state_op)
   {
-    moveit::core::robotStateToRobotStateMsg(rob_state_op.value(), start_state);
+    moveit::core::robotStateToRobotStateMsg(rob_state_op.value(), start_state, false);
   }
 }
 

--- a/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/command_list_manager.cpp
@@ -173,6 +173,7 @@ void CommandListManager::setStartState(const MotionResponseCont& motion_plan_res
   if (rob_state_op)
   {
     moveit::core::robotStateToRobotStateMsg(rob_state_op.value(), start_state, false);
+    start_state.is_diff = true;
   }
 }
 


### PR DESCRIPTION
### Description

#3569 describes propagation of error from updating collision objects with each update of the start state during a sequence motion plan.

#3589 attempts to speed up plans by updating only joints positions when updating the start state, though this may cause the RobotState to ignore collision objects entirely if the state being updated has no knowledge of them.

This PR attempts to fix both issues by only updating the joints of a sequence motion, without copying across attached collision objects, in the hope that the start state being updated is already populated with attached collision object information.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/) (No major changes to user-facing functionality)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes (Changes implementation details / fixes error cases)
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html) (See findings below)
- [x] Include a screenshot if changing a GUI (No GUI changes)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
