### PR TITLE
Allows MoveGroupInterface to use RobotState diffs as start states

### DIFF
--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -466,7 +466,7 @@ public:
 
   moveit::core::RobotStatePtr getStartState()
   {
-    moveit::core::RobotStatePtr = getCurrentState();
+    moveit::core::RobotStatePtr s = getCurrentState();
     moveit::core::robotStateMsgToRobotState(considered_start_state_, *s, true);
     return s;
   }

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -461,7 +461,9 @@ public:
 
   void setStartStateToCurrentState()
   {
+    // set message to empty diff
     considered_start_state_ = moveit_msgs::RobotState();
+    considered_start_state_.is_diff = true;
   }
 
   moveit::core::RobotStatePtr getStartState()

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -949,7 +949,7 @@ public:
 
     if (considered_start_state_)
       req.start_state = considered_start_state_;
-    else 
+    else
     {
       // If there is no considered start state, this is an empty diff
       // i.e. the current state will be used.
@@ -1108,7 +1108,7 @@ public:
       // i.e. the current state will be used.
       request.start_state.is_diff = true;
     }
-      
+
     if (active_target_ == JOINT)
     {
       request.goal_constraints.resize(1);

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -448,26 +448,30 @@ public:
     return *joint_state_target_;
   }
 
+  void setStartState(const moveit_msgs::RobotState& start_state)
+  {
+    considered_start_state_ = start_state;
+  }
+
   void setStartState(const moveit::core::RobotState& start_state)
   {
-    considered_start_state_ = std::make_shared<moveit::core::RobotState>(start_state);
+    considered_start_state_ = moveit_msgs::RobotState();
+    moveit::core::robotStateToRobotStateMsg(start_state, *considered_start_state_, true);
   }
 
   void setStartStateToCurrentState()
   {
-    considered_start_state_.reset();
+    considered_start_state_ = std::nullopt;
   }
 
   moveit::core::RobotStatePtr getStartState()
   {
+    moveit::core::RobotStatePtr s;
     if (considered_start_state_)
-      return considered_start_state_;
+      moveit::core::robotStateMsgToRobotState(*considered_start_state_, *s, true);
     else
-    {
-      moveit::core::RobotStatePtr s;
       getCurrentState(s);
-      return s;
-    }
+    return s;
   }
 
   bool setJointValueTarget(const geometry_msgs::Pose& eef_pose, const std::string& end_effector_link,
@@ -944,9 +948,13 @@ public:
     moveit_msgs::GetCartesianPath::Response res;
 
     if (considered_start_state_)
-      moveit::core::robotStateToRobotStateMsg(*considered_start_state_, req.start_state);
-    else
+      req.start_state = considered_start_state_;
+    else 
+    {
+      // If there is no considered start state, this is an empty diff
+      // i.e. the current state will be used.
       req.start_state.is_diff = true;
+    }
 
     req.group_name = opt_.group_name_;
     req.header.frame_id = getPoseReferenceFrame();
@@ -1093,10 +1101,14 @@ public:
     request.workspace_parameters = workspace_parameters_;
 
     if (considered_start_state_)
-      moveit::core::robotStateToRobotStateMsg(*considered_start_state_, request.start_state);
+      request.start_state = considered_start_state_;
     else
+    {
+      // If there is no considered start state, this is an empty diff
+      // i.e. the current state will be used.
       request.start_state.is_diff = true;
-
+    }
+      
     if (active_target_ == JOINT)
     {
       request.goal_constraints.resize(1);
@@ -1318,7 +1330,7 @@ private:
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PlaceAction>> place_action_client_;
 
   // general planning params
-  moveit::core::RobotStatePtr considered_start_state_;
+  std::optional<moveit_msgs::RobotState> considered_start_state_;
   moveit_msgs::WorkspaceParameters workspace_parameters_;
   double allowed_planning_time_;
   std::string planning_pipeline_id_;
@@ -1623,16 +1635,7 @@ void MoveGroupInterface::stop()
 
 void MoveGroupInterface::setStartState(const moveit_msgs::RobotState& start_state)
 {
-  moveit::core::RobotStatePtr rs;
-  if (start_state.is_diff)
-    impl_->getCurrentState(rs);
-  else
-  {
-    rs = std::make_shared<moveit::core::RobotState>(getRobotModel());
-    rs->setToDefaultValues();  // initialize robot state values for conversion
-  }
-  moveit::core::robotStateMsgToRobotState(start_state, *rs);
-  setStartState(*rs);
+  impl_->setStartState(start_state);
 }
 
 void MoveGroupInterface::setStartState(const moveit::core::RobotState& start_state)

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -948,7 +948,7 @@ public:
     moveit_msgs::GetCartesianPath::Response res;
 
     if (considered_start_state_)
-      req.start_state = considered_start_state_;
+      req.start_state = *considered_start_state_;
     else
     {
       // If there is no considered start state, this is an empty diff
@@ -1101,7 +1101,7 @@ public:
     request.workspace_parameters = workspace_parameters_;
 
     if (considered_start_state_)
-      request.start_state = considered_start_state_;
+      request.start_state = *considered_start_state_;
     else
     {
       // If there is no considered start state, this is an empty diff

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -117,6 +117,7 @@ public:
 
     joint_model_group_ = getRobotModel()->getJointModelGroup(opt.group_name_);
 
+    setStartStateToCurrentState();
     joint_state_target_ = std::make_shared<moveit::core::RobotState>(getRobotModel());
     joint_state_target_->setToDefaultValues();
     active_target_ = JOINT;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -456,21 +456,18 @@ public:
   void setStartState(const moveit::core::RobotState& start_state)
   {
     considered_start_state_ = moveit_msgs::RobotState();
-    moveit::core::robotStateToRobotStateMsg(start_state, *considered_start_state_, true);
+    moveit::core::robotStateToRobotStateMsg(start_state, considered_start_state_, true);
   }
 
   void setStartStateToCurrentState()
   {
-    considered_start_state_ = std::nullopt;
+    considered_start_state_ = moveit_msgs::RobotState();
   }
 
   moveit::core::RobotStatePtr getStartState()
   {
-    moveit::core::RobotStatePtr s;
-    if (considered_start_state_)
-      moveit::core::robotStateMsgToRobotState(*considered_start_state_, *s, true);
-    else
-      getCurrentState(s);
+    moveit::core::RobotStatePtr = getCurrentState();
+    moveit::core::robotStateMsgToRobotState(considered_start_state_, *s, true);
     return s;
   }
 
@@ -947,15 +944,7 @@ public:
     moveit_msgs::GetCartesianPath::Request req;
     moveit_msgs::GetCartesianPath::Response res;
 
-    if (considered_start_state_)
-      req.start_state = *considered_start_state_;
-    else
-    {
-      // If there is no considered start state, this is an empty diff
-      // i.e. the current state will be used.
-      req.start_state.is_diff = true;
-    }
-
+    req.start_state = considered_start_state_;
     req.group_name = opt_.group_name_;
     req.header.frame_id = getPoseReferenceFrame();
     req.header.stamp = ros::Time::now();
@@ -1099,15 +1088,7 @@ public:
     request.pipeline_id = planning_pipeline_id_;
     request.planner_id = planner_id_;
     request.workspace_parameters = workspace_parameters_;
-
-    if (considered_start_state_)
-      request.start_state = *considered_start_state_;
-    else
-    {
-      // If there is no considered start state, this is an empty diff
-      // i.e. the current state will be used.
-      request.start_state.is_diff = true;
-    }
+    request.start_state = considered_start_state_;
 
     if (active_target_ == JOINT)
     {
@@ -1330,7 +1311,7 @@ private:
   std::unique_ptr<actionlib::SimpleActionClient<moveit_msgs::PlaceAction>> place_action_client_;
 
   // general planning params
-  std::optional<moveit_msgs::RobotState> considered_start_state_;
+  moveit_msgs::RobotState considered_start_state_;
   moveit_msgs::WorkspaceParameters workspace_parameters_;
   double allowed_planning_time_;
   std::string planning_pipeline_id_;

--- a/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
+++ b/moveit_ros/planning_interface/move_group_interface/src/move_group_interface.cpp
@@ -466,7 +466,8 @@ public:
 
   moveit::core::RobotStatePtr getStartState()
   {
-    moveit::core::RobotStatePtr s = getCurrentState();
+    moveit::core::RobotStatePtr s;
+    getCurrentState(s);
     moveit::core::robotStateMsgToRobotState(considered_start_state_, *s, true);
     return s;
   }


### PR DESCRIPTION
### Description

This PR modifies the `considered_start_state_` member of `MoveGroupInterface` to use a `moveit_msgs::RobotState` rather than a `robot_state::RobotStatePtr`. This prevents unnecessary conversion to and from the message type when planning, and allows start states to be set with `RobotState` diff messages, preventing unnecessary passing around / conversion of entire `RobotState`s when planning.

Methods exposing the `considered_start_state_` member have been updated to avoid making breaking changes to the API.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [x] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/) (No changes to user-facing functionality)
- [x] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes (preserves existing API)
- [x] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html) (Modifies implementation details. Should preserve existing test behaviour)
- [x] Include a screenshot if changing a GUI (No GUI changes)
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
