### PR TITLE
CHOMP: Fix handling of mimic joints

### DIFF
--- a/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
+++ b/moveit_planners/chomp/chomp_motion_planner/src/chomp_optimizer.cpp
@@ -998,7 +998,7 @@ void ChompOptimizer::setRobotStateFromPoint(ChompTrajectory& group_trajectory, i
   for (size_t j = 0; j < group_trajectory.getNumJoints(); j++)
     joint_states.emplace_back(point(0, j));
 
-  state_.setJointGroupPositions(planning_group_, joint_states);
+  state_.setJointGroupActivePositions(planning_group_, joint_states);
   state_.update();
 }
 


### PR DESCRIPTION
As the CHOMP planner only considers active joints:
https://github.com/moveit/moveit/blob/7a51eeae283512e8f4364bdd1fab009bd7e7a93d/moveit_planners/chomp/chomp_motion_planner/src/chomp_trajectory.cpp#L58
it needs to call `setJointGroupActivePositions()` instead of `setJointGroupPositions()`. Otherwise, this assertion fails:
https://github.com/moveit/moveit/blob/7a51eeae283512e8f4364bdd1fab009bd7e7a93d/moveit_core/robot_state/include/moveit/robot_state/robot_state.h#L643