### PR TITLE
PoseModelStateSpace: Reintroduce Cartesian interpolation

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/parameterization/work_space/pose_model_state_space.h
@@ -137,5 +137,6 @@ private:
   };
 
   std::vector<PoseComponent> poses_;
+  double jump_factor_;
 };
 }  // namespace ompl_interface

--- a/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/parameterization/work_space/pose_model_state_space.cpp
@@ -127,13 +127,8 @@ void ompl_interface::PoseModelStateSpace::interpolate(const ompl::base::State* f
 
   // we want to interpolate in Cartesian space to avoid rejection of path constraints
 
+  // interpolate in joint space to find a suitable seed for IK
   ModelBasedStateSpace::interpolate(from, to, t, state);
-  double d_joint = ModelBasedStateSpace::distance(from, state);
-
-  // seed IK from start state
-  memcpy(state->as<StateType>()->values, from->as<StateType>()->values, state_values_size_);
-  state->as<StateType>()->setJointsComputed(false);
-  state->as<StateType>()->tag = -1;
 
   // interpolate SE3 components
   for (std::size_t i = 0; i < poses_.size(); ++i)
@@ -144,14 +139,7 @@ void ompl_interface::PoseModelStateSpace::interpolate(const ompl::base::State* f
   state->as<StateType>()->setPoseComputed(true);
 
   // compute IK for interpolated Cartesian state
-  if (computeStateIK(state))
-  {
-    double d_cart = ModelBasedStateSpace::distance(from, state);
-
-    // reject if Cartesian interpolation yields much larger distance than joint interpolation
-    if (d_cart > 1.1 * d_joint)
-      state->as<StateType>()->markInvalid();
-  }
+  computeStateIK(state);
 }
 
 void ompl_interface::PoseModelStateSpace::setPlanningVolume(double minX, double maxX, double minY, double maxY,


### PR DESCRIPTION
I noticed that #3615 resulted in planning timeouts for [code that previously worked](https://github.com/moveit/moveit_task_constructor/blob/69b4606bca5a5c117a5bcad1a60ee94dfe920730/demo/scripts/constrained.py#L48-L58). I had to drastically increase the timeout or relax the path constraints to make it work again.
Obviously, using joint-space interpolation much more often results in rejection of tight path constraints than Cartesian interpolation did.
Reintroducing Cartesian interpolation, it turns out that this wasn't really the culprit. Only measuring distances in Cartesian space was.