### PR TITLE
Fix planning_scene_monitor sync when passed empty robot state

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -588,7 +588,7 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningSc
     if (!scene.is_diff && parent_scene_)
     {
       // If there is no new robot_state, transfer RobotState from current scene to parent scene
-      if (scene.robot_state.joint_state.name.empty() && scene.robot_state.multi_dof_joint_state.joint_names.empty())
+      if (scene.robot_state.is_diff)
         parent_scene_->setCurrentState(scene_->getCurrentState());
       scene_->clearDiffs();
       result = parent_scene_->setPlanningSceneMsg(scene);


### PR DESCRIPTION
Backport of https://github.com/moveit/moveit2/pull/3187