### PR TITLE
[WIP] Account for the collision environment cache when moving a collision object

### DIFF
--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_common.h
@@ -297,7 +297,8 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
 /** \brief Create new FCLGeometry object out of a world object.
  *
  *  A world object always consists only of a single shape, therefore we don't need the \e shape_index. */
-FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const World::Object* obj);
+FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, const World::Object* obj,
+                                            fcl::CollisionGeometryd* cg_g = nullptr);
 
 /** \brief Create new scaled and / or padded FCLGeometry object out of robot link model. */
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
@@ -309,7 +310,7 @@ FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, 
 
 /** \brief Create new scaled and / or padded FCLGeometry object out of an world object. */
 FCLGeometryConstPtr createCollisionGeometry(const shapes::ShapeConstPtr& shape, double scale, double padding,
-                                            const World::Object* obj);
+                                            const World::Object* obj, fcl::CollisionGeometryd* cg_g = nullptr);
 
 /** \brief Increases the counter of the caches which can trigger the cleaning of expired entries from them. */
 void cleanCollisionGeometryCache();

--- a/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
+++ b/moveit_core/collision_detection_fcl/include/moveit/collision_detection_fcl/collision_env_fcl.h
@@ -111,6 +111,9 @@ protected:
   /** \brief Construct an FCL collision object from MoveIt's World::Object. */
   void constructFCLObjectWorld(const World::Object* obj, FCLObject& fcl_obj) const;
 
+  /** \brief Update an FCL collision object from MoveIt's World::Object. */
+  void updateFCLObjectWorld(const World::Object* obj, FCLObject& fcl_obj) const;
+
   /** \brief Updates the specified object in \c fcl_objs_ and in the manager from new data available in the World.
    *
    *  If it does not exist in world, it is deleted. If it's not existing in \c fcl_objs_ yet, it's added there. */


### PR DESCRIPTION
PR #3601 did not account for the cache (or other initialization) when moving an object.

I have a situation where there is a collision between the lid and the pipette (left picture), but when checking closely there is none, e.g. the lid is open ! But at the start of the task, the lid is closed (right picture) and later on moved though the MOVE operation. So I reverted PR 3601 and there were no more errors, but the meshes were all recreated from scratch...

The only thing I can think off is that it used a cached version of the object from the initial state (it could also be my setup). I can reproduce this behaviour on my setup.

This PR now passes a MOVE operation to the `createCollisionGeometry` method where the local threaded cache is used. Instead of recreating the mesh from scratch it uses the collision geometry already computed from the ADD operation.
```bash
[ INFO] [1738621864.855714824]: Found a contact between 'thermocycler' (type 'Object') and 'pipette_base' (type 'Robot link'), which constitutes a collision. Contact information is not stored.
[ INFO] [1738621864.855768469]: Collision checking is considered complete (collision was found and 0 contacts are stored)
  0  - ←   0 →   -  0 / Move to joint
    0  - ←   0 →   -  0 / fixed state
    -  0 →   0 →   -  0 / Move Relative Above Bottom Container
    -  0 →   0 →   -  0 / dispense_liquid
    -  0 →   0 →   -  0 / mix_liquid
    -  0 →   0 →   -  0 / dispense_liquid
    -  0 →   0 →   -  0 / assert max distance
      -  0 →   0 →   -  0 / move to joint constraint
Failing stage(s):
fixed state (0/1): in collision
[ WARN] [1738621864.855978472]: Plan failed
```
<p align="middle">

<img src="https://github.com/user-attachments/assets/87759370-7aa6-4b4a-92e6-62c566397a28" width="48%" />
  <img src="https://github.com/user-attachments/assets/45c27c2e-a40c-4d85-873a-6b5c972c1f58" width="48%" />
  
</p>

My first attempt on adding a test could not reproduce the error I see in my setup. Will have to reattempt later.


