### PR TITLE
Satisfies bounds for outer joint position, velocity and acceleration

### DIFF
--- a/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
+++ b/moveit_core/robot_model/include/moveit/robot_model/joint_model.h
@@ -280,6 +280,15 @@ public:
   }
 
   /** \brief Check if the set of position values for the variables of this joint are within bounds, up to some margin.
+   *  Inner bounds: margin >= 0.0
+   *
+   *        |   False   |   True   |   True   |   True   |   False   |
+   *      -inf        margin      min        max       margin      +inf
+   *
+   *  Outer bounds: margin < 0.0
+   *
+   *        |   True   |   True   |   False   |   True   |   True   |
+   *      -inf        min       margin      margin      max       +inf
    */
   virtual bool satisfiesPositionBounds(const double* values, const Bounds& other_bounds, double margin) const = 0;
 

--- a/moveit_core/robot_model/src/floating_joint_model.cpp
+++ b/moveit_core/robot_model/src/floating_joint_model.cpp
@@ -159,12 +159,25 @@ void FloatingJointModel::interpolate(const double* from, const double* to, const
 
 bool FloatingJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
-  if (values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin)
-    return false;
-  if (values[1] < bounds[1].min_position_ - margin || values[1] > bounds[1].max_position_ + margin)
-    return false;
-  if (values[2] < bounds[2].min_position_ - margin || values[2] > bounds[2].max_position_ + margin)
-    return false;
+  if (margin >= 0.0)
+  {
+    if (values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin)
+      return false;
+    if (values[1] < bounds[1].min_position_ - margin || values[1] > bounds[1].max_position_ + margin)
+      return false;
+    if (values[2] < bounds[2].min_position_ - margin || values[2] > bounds[2].max_position_ + margin)
+      return false;
+  }
+  else
+  {
+    if (!(values[0] <= bounds[0].min_position_ - margin || values[0] >= bounds[0].max_position_ + margin))
+      return false;
+    if (!(values[1] <= bounds[1].min_position_ - margin || values[1] >= bounds[1].max_position_ + margin))
+      return false;
+    if (!(values[2] <= bounds[2].min_position_ - margin || values[2] >= bounds[2].max_position_ + margin))
+      return false;
+  }
+
   double norm_sqr = values[3] * values[3] + values[4] * values[4] + values[5] * values[5] + values[6] * values[6];
   return fabs(norm_sqr - 1.0) <= std::numeric_limits<float>::epsilon() * 10.0;
 }

--- a/moveit_core/robot_model/src/joint_model.cpp
+++ b/moveit_core/robot_model/src/joint_model.cpp
@@ -120,10 +120,17 @@ bool JointModel::satisfiesVelocityBounds(const double* values, const Bounds& oth
     {
       continue;
     }
-    if (other_bounds[i].max_velocity_ + margin < values[i])
-      return false;
-    else if (other_bounds[i].min_velocity_ - margin > values[i])
-      return false;
+
+    if (margin >= 0.0)
+    {
+      if (values[i] < other_bounds[i].min_velocity_ - margin || values[i] > other_bounds[i].max_velocity_ + margin)
+        return false;
+    }
+    else
+    {
+      if (!(values[i] <= other_bounds[i].min_velocity_ - margin || values[i] >= other_bounds[i].max_velocity_ + margin))
+        return false;
+    }
   }
   return true;
 }
@@ -136,10 +143,18 @@ bool JointModel::satisfiesAccelerationBounds(const double* values, const Bounds&
     {
       continue;
     }
-    if (other_bounds[i].max_acceleration_ + margin < values[i])
-      return false;
-    else if (other_bounds[i].min_acceleration_ - margin > values[i])
-      return false;
+
+    if (margin >= 0.0)
+    {
+      if (values[i] < other_bounds[i].min_acceleration_ - margin || values[i] > other_bounds[i].max_velocity_ + margin)
+        return false;
+    }
+    else
+    {
+      if (!(values[i] <= other_bounds[i].min_acceleration_ - margin ||
+            values[i] >= other_bounds[i].max_velocity_ + margin))
+        return false;
+    }
   }
   return true;
 }

--- a/moveit_core/robot_model/src/planar_joint_model.cpp
+++ b/moveit_core/robot_model/src/planar_joint_model.cpp
@@ -286,9 +286,18 @@ double PlanarJointModel::distance(const double* values1, const double* values2) 
 
 bool PlanarJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
-  for (unsigned int i = 0; i < 3; ++i)
-    if (values[i] < bounds[i].min_position_ - margin || values[i] > bounds[i].max_position_ + margin)
-      return false;
+  if (margin >= 0.0)
+  {
+    for (unsigned int i = 0; i < 3; ++i)
+      if (values[i] < bounds[i].min_position_ - margin || values[i] > bounds[i].max_position_ + margin)
+        return false;
+  }
+  else
+  {
+    for (unsigned int i = 0; i < 3; ++i)
+      if (!(values[i] <= bounds[i].min_position_ - margin || values[i] >= bounds[i].max_position_ + margin))
+        return false;
+  }
   return true;
 }
 

--- a/moveit_core/robot_model/src/prismatic_joint_model.cpp
+++ b/moveit_core/robot_model/src/prismatic_joint_model.cpp
@@ -74,7 +74,10 @@ void PrismaticJointModel::getVariableDefaultPositions(double* values, const Boun
 
 bool PrismaticJointModel::satisfiesPositionBounds(const double* values, const Bounds& bounds, double margin) const
 {
-  return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
+  if (margin >= 0.0)
+    return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
+  else
+    return (values[0] <= bounds[0].min_position_ - margin || values[0] >= bounds[0].max_position_ + margin);
 }
 
 void PrismaticJointModel::getVariableRandomPositions(random_numbers::RandomNumberGenerator& rng, double* values,

--- a/moveit_core/robot_model/src/revolute_joint_model.cpp
+++ b/moveit_core/robot_model/src/revolute_joint_model.cpp
@@ -163,7 +163,12 @@ bool RevoluteJointModel::satisfiesPositionBounds(const double* values, const Bou
   if (continuous_)
     return true;
   else
-    return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
+  {
+    if (margin >= 0.0)
+      return !(values[0] < bounds[0].min_position_ - margin || values[0] > bounds[0].max_position_ + margin);
+    else
+      return (values[0] <= bounds[0].min_position_ - margin || values[0] >= bounds[0].max_position_ + margin);
+  }
 }
 
 bool RevoluteJointModel::harmonizePosition(double* values, const JointModel::Bounds& other_bounds) const

--- a/moveit_core/robot_model/test/test.cpp
+++ b/moveit_core/robot_model/test/test.cpp
@@ -191,6 +191,21 @@ void generateMotionBoundsTests(const moveit::core::JointModel& joint_model,
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[0][0], bounds, -1));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[0][0], bounds, -1.1));
 
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, 0));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, 0.9));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, 1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, 1.1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, -0.9));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, -1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, -1.1));
+
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, 0));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, 0.9));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, 1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, 1.1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, -0.9));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, -1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, -1.1));
   }
   else
   {
@@ -198,10 +213,25 @@ void generateMotionBoundsTests(const moveit::core::JointModel& joint_model,
     ASSERT_FALSE(joint_model.satisfiesPositionBounds(&position_2d[0][0], bounds, 0.9));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[0][0], bounds, 1));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[0][0], bounds, 1.1));
-
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[0][0], bounds, -0.9));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[0][0], bounds, -1));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[0][0], bounds, -1.1));
+
+    ASSERT_FALSE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, 0));
+    ASSERT_FALSE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, 0.9));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, 1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, 1.1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, -0.9));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, -1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[0][0], bounds, -1.1));
+
+    ASSERT_FALSE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, 0));
+    ASSERT_FALSE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, 0.9));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, 1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, 1.1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, -0.9));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, -1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[0][0], bounds, -1.1));
   }
 
   //      |          X----------|-------------|----------|          |
@@ -210,32 +240,81 @@ void generateMotionBoundsTests(const moveit::core::JointModel& joint_model,
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[1][0], bounds, 0.9));
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[1][0], bounds, 1));
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[1][0], bounds, 1.1));
-
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[1][0], bounds, -0.9));
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[1][0], bounds, -1));
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[1][0], bounds, -1.1));
+
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[1][0], bounds, 0));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[1][0], bounds, 0.9));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[1][0], bounds, 1));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[1][0], bounds, 1.1));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[1][0], bounds, -0.9));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[1][0], bounds, -1));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[1][0], bounds, -1.1));
+
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[1][0], bounds, 0));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[1][0], bounds, 0.9));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[1][0], bounds, 1));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[1][0], bounds, 1.1));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[1][0], bounds, -0.9));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[1][0], bounds, -1));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[1][0], bounds, -1.1));
 
   //      |          |----------X-------------|----------|          |
   //  (min - 1)     min     (min + 1)     (max - 1)     max     (max + 1)
   if (compute_inner)
   {
-    std::cout << "compute inner" << std::endl;
-    ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 0));
-    ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 0.9));
-    ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 1));
-    ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 1.1));
-
     if (inf_min_bounded)
     {
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 1.1));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, -0.9));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, -1));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, -1.1));
+
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, 1.1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, -0.9));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, -1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, -1.1));
+
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, 1.1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, -0.9));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, -1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, -1.1));
     }
     else
     {
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, 1.1));
       ASSERT_FALSE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, -0.9));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, -1));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[2][0], bounds, -1.1));
+
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, 1.1));
+      ASSERT_FALSE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, -0.9));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, -1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[2][0], bounds, -1.1));
+
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, 1.1));
+      ASSERT_FALSE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, -0.9));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, -1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[2][0], bounds, -1.1));
     }
   }
 
@@ -243,23 +322,57 @@ void generateMotionBoundsTests(const moveit::core::JointModel& joint_model,
   //  (min - 1)     min     (min + 1)     (max - 1)     max     (max + 1)
   if (compute_inner)
   {
-    std::cout << "compute inner" << std::endl;
-    ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 0));
-    ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 0.9));
-    ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 1));
-    ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 1.1));
-
     if (inf_max_bounded)
     {
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 1.1));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, -0.9));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, -1));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, -1.1));
+
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, 1.1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, -0.9));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, -1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, -1.1));
+
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, 1.1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, -0.9));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, -1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, -1.1));
     }
     else
     {
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, 1.1));
       ASSERT_FALSE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, -0.9));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, -1));
       ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[3][0], bounds, -1.1));
+
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, 1.1));
+      ASSERT_FALSE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, -0.9));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, -1));
+      ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[3][0], bounds, -1.1));
+
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, 0));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, 0.9));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, 1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, 1.1));
+      ASSERT_FALSE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, -0.9));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, -1));
+      ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[3][0], bounds, -1.1));
     }
   }
 
@@ -269,10 +382,25 @@ void generateMotionBoundsTests(const moveit::core::JointModel& joint_model,
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[4][0], bounds, 0.9));
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[4][0], bounds, 1));
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[4][0], bounds, 1.1));
-
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[4][0], bounds, -0.9));
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[4][0], bounds, -1));
   ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[4][0], bounds, -1.1));
+
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[4][0], bounds, 0));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[4][0], bounds, 0.9));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[4][0], bounds, 1));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[4][0], bounds, 1.1));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[4][0], bounds, -0.9));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[4][0], bounds, -1));
+  ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[4][0], bounds, -1.1));
+
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[4][0], bounds, 0));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[4][0], bounds, 0.9));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[4][0], bounds, 1));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[4][0], bounds, 1.1));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[4][0], bounds, -0.9));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[4][0], bounds, -1));
+  ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[4][0], bounds, -1.1));
 
   //      |          |----------|-------------|----------|          X
   //  (min - 1)     min     (min + 1)     (max - 1)     max     (max + 1)
@@ -282,10 +410,25 @@ void generateMotionBoundsTests(const moveit::core::JointModel& joint_model,
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, 0.9));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, 1));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, 1.1));
-
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, -0.9));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, -1));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, -1.1));
+
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, 0));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, 0.9));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, 1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, 1.1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, -0.9));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, -1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, -1.1));
+
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, 0));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, 0.9));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, 1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, 1.1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, -0.9));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, -1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, -1.1));
   }
   else
   {
@@ -293,10 +436,25 @@ void generateMotionBoundsTests(const moveit::core::JointModel& joint_model,
     ASSERT_FALSE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, 0.9));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, 1));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, 1.1));
-
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, -0.9));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, -1));
     ASSERT_TRUE(joint_model.satisfiesPositionBounds(&position_2d[5][0], bounds, -1.1));
+
+    ASSERT_FALSE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, 0));
+    ASSERT_FALSE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, 0.9));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, 1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, 1.1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, -0.9));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, -1));
+    ASSERT_TRUE(joint_model.satisfiesVelocityBounds(&velocity_2d[5][0], bounds, -1.1));
+
+    ASSERT_FALSE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, 0));
+    ASSERT_FALSE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, 0.9));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, 1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, 1.1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, -0.9));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, -1));
+    ASSERT_TRUE(joint_model.satisfiesAccelerationBounds(&acceleration_2d[5][0], bounds, -1.1));
   }
 }
 


### PR DESCRIPTION
### Description

My end goal is to warn the user if the planning failed due to being close to joint bounds in MTC, within a certain margin:
```cpp
double margin = -0.1  // ~6 degrees
if (last_waypoint->satisfiesBounds(jmg, margin)) 
    ROS_WARN_STREAM("Waypoint is within the margin of position bounds: margin = " + std::to_string(margin));

// oversimplification, one would need to set different margins depending on the joint type
```
To this end, one can now check if the joints are within the outer bounds (when margin < 0.0). 
```cpp
  /** \brief Check if the set of position values for the variables of this joint are within bounds, up to some margin.
   *  Inner bounds: margin >= 0.0
   *
   *        |   False   |   True   |   True   |   True   |   False   |
   *      -inf        margin      min        max       margin      +inf
   *
   *  Outer bounds: margin < 0.0
   *
   *        |   True   |   True   |   False   |   True   |   True   |
   *      -inf        min       margin      margin      max       +inf
   */
```

Does this makes sense ? Or is there something already available ?

### Checklist
- [X] Revolute
- [X] Prismatic
- [x] Floating
- [x] Planar
- [x] Velocity + Acceleration
- [x] Tests

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
