### PR TITLE
Fix Issue 3703

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
 
 
     name: "${{ matrix.env.IMAGE }}${{ matrix.env.NAME }}${{ matrix.env.CATKIN_LINT && ' + catkin_lint' || ''}}${{ matrix.env.CCOV && ' + ccov' || ''}}${{ matrix.env.IKFAST_TEST && ' + ikfast' || ''}}${{ matrix.env.CLANG_TIDY && (github.event_name != 'workflow_dispatch' && ' + clang-tidy (delta)' || ' + clang-tidy (all)') || '' }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Free up disk space"
         if: matrix.env.CCOV

--- a/moveit_ros/moveit_servo/src/servo_server.cpp
+++ b/moveit_ros/moveit_servo/src/servo_server.cpp
@@ -68,7 +68,20 @@ int main(int argc, char** argv)
       planning_scene_monitor::PlanningSceneMonitor::DEFAULT_COLLISION_OBJECT_TOPIC,
       planning_scene_monitor::PlanningSceneMonitor::DEFAULT_PLANNING_SCENE_WORLD_TOPIC,
       false /* skip octomap monitor */);
-  planning_scene_monitor->startStateMonitor();
+
+  // Read joint_topic; if default, subscribe now; else defer to Servo
+  std::string joint_topic;
+  nh.param<std::string>("joint_topic", joint_topic,
+                        planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC);
+  if (joint_topic == planning_scene_monitor::PlanningSceneMonitor::DEFAULT_JOINT_STATES_TOPIC)
+  {
+    planning_scene_monitor->startStateMonitor();
+  }
+  else
+  {
+    ROS_INFO_STREAM_NAMED(LOGNAME, "Custom joint_topic '"
+                                       << joint_topic << "' detected; deferring state monitor to Servo constructor.");
+  }
 
   // Create the servo server
   moveit_servo::Servo servo(nh, planning_scene_monitor);


### PR DESCRIPTION
### Description
Updates servo_server.cpp so that planning_scene_monitor->startStateMonitor() is only called immediately when using the default /joint_states topic. If a custom ~joint_topic is configured, the call is skipped in main() and deferred to the Servo constructor, ensuring the node subscribes to the correct topic.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
