### PR TITLE
Properly diff attached objects to avoid missing changes

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -653,7 +653,21 @@ void PlanningScene::getPlanningSceneDiffMsg(moveit_msgs::PlanningScene& scene_ms
     scene_msg.fixed_frame_transforms.clear();
 
   if (robot_state_)
+  {
     moveit::core::robotStateToRobotStateMsg(*robot_state_, scene_msg.robot_state);
+    // only include attached objects if they changed
+    if (parent_)
+    {
+      std::vector<const moveit::core::AttachedBody*> ab;
+      robot_state_->getAttachedBodies(ab);
+      std::vector<const moveit::core::AttachedBody*> pab;
+      parent_->robot_state_->getAttachedBodies(pab);
+      if (pab == ab)
+      {
+        scene_msg.robot_state.attached_collision_objects.clear();
+      }
+    }
+  }
   else
     scene_msg.robot_state = moveit_msgs::RobotState();
   scene_msg.robot_state.is_diff = true;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -393,11 +393,6 @@ void PlanningSceneMonitor::scenePublishingThread()
             if (octomap_monitor_)
               lock = octomap_monitor_->getOcTreePtr()->reading();
             scene_->getPlanningSceneDiffMsg(msg);
-            if (new_scene_update_ == UPDATE_STATE)
-            {
-              msg.robot_state.attached_collision_objects.clear();
-              msg.robot_state.is_diff = true;
-            }
           }
           boost::recursive_mutex::scoped_lock prevent_shape_cache_updates(shape_handles_lock_);  // we don't want the
                                                                                                  // transform cache to


### PR DESCRIPTION
### Description

We noticed recently that attached objects would pile up over time in some cases if a state update arrived between attaching an object (`processAttachedCollisionObjectMsg(aco);`) and notifying of the change (` planningSceneMonitor->triggerSceneUpdateEvent(PlanningSceneMonitor::UPDATE_GEOMETRY);`)

This was triggered by my optimization in #2049 after which attached objects were implicitely removed by `is_diff == false` and having no attached objects. In #3124 all robot_state messages were switched to `is_diff == true` thus if the race condition above happens the change could get lost.

In this PR now attached objects are actually diffed now.

Our software does not currently allow attaching more than one object, would be very grateful if someone could cross check it works there as well.

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
