### PR TITLE
Fix duplicate action_ns and default keys in simple controller

### DIFF
--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -960,14 +960,14 @@ bool MoveItConfigData::outputSimpleControllersYAML(const std::string& file_path)
 
   for (const auto& controller : controller_configs_)
   {
-    if  (!written_checker.insert(controller.name_).second)
-      continue;
     // Only process FollowJointTrajectory types
     std::string type = controller.type_;
     if (boost::ends_with(type, "/JointTrajectoryController"))
       type = "FollowJointTrajectory";
     if (type == "FollowJointTrajectory" || type == "GripperCommand")
     {
+      if (!written_checker.insert(controller.name_).second) // FIX
+        continue;
       emitter << YAML::BeginMap;
       emitter << YAML::Key << "name";
       emitter << YAML::Value << controller.name_;

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -954,8 +954,14 @@ bool MoveItConfigData::outputSimpleControllersYAML(const std::string& file_path)
   emitter << YAML::BeginMap;
   emitter << YAML::Key << "controller_list";
   emitter << YAML::Value << YAML::BeginSeq;
+
+  // Preven duplicate
+  std::set<std::string> written_checker;
+
   for (const auto& controller : controller_configs_)
   {
+    if  (!written_checker.insert(controller.name_).second)
+      continue;
     // Only process FollowJointTrajectory types
     std::string type = controller.type_;
     if (boost::ends_with(type, "/JointTrajectoryController"))
@@ -970,8 +976,8 @@ bool MoveItConfigData::outputSimpleControllersYAML(const std::string& file_path)
       emitter << YAML::Key << "type";
       emitter << YAML::Value << type;
       emitter << YAML::Key << "default";
-      emitter << YAML::Value << "True";
-
+      emitter << YAML::Value << true;
+      
       // Write joints
       emitter << YAML::Key << "joints";
       emitter << YAML::Value << YAML::BeginSeq;


### PR DESCRIPTION
This PR fixes a bug in outputSimpleControllersYAML() where duplicate YAML keys (action_ns and default) were being generated for the same controller entry when processing controller_configs_ [#3434 ](https://github.com/moveit/moveit2/issues/3434).

When generating the simple controllers YAML, controllers could be written multiple times, resulting in duplicated fields

In order to fix this I Added a std::set<std::string> to track which controllers have already been written.
Thereby skipping duplicate controller entries using the if case: 
if (!written_checker.insert(controller.name_).second)
  continue;
