### PR TITLE
Fix typos: occured -> occurred

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -98,7 +98,7 @@ struct Contact
   /** \brief The distance percentage between casted poses until collision.
    *
    *  If the value is 0, then the collision occurred in the start pose. If the value is 1, then the collision occurred
-  *  in the end pose. */
+   *  in the end pose. */
   double percent_interpolation;
 
   /** \brief The two nearest points connecting the two bodies */

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -97,7 +97,7 @@ struct Contact
 
   /** \brief The distance percentage between casted poses until collision.
    *
-   *  If the value is 0, then the collision occured in the start pose. If the value is 1, then the collision occured in
+   *  If the value is 0, then the collision occurred in the start pose. If the value is 1, then the collision occurred in
    *  the end pose. */
   double percent_interpolation;
 

--- a/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/collision_common.h
@@ -97,8 +97,8 @@ struct Contact
 
   /** \brief The distance percentage between casted poses until collision.
    *
-   *  If the value is 0, then the collision occurred in the start pose. If the value is 1, then the collision occurred in
-   *  the end pose. */
+   *  If the value is 0, then the collision occurred in the start pose. If the value is 1, then the collision occurred
+  *  in the end pose. */
   double percent_interpolation;
 
   /** \brief The two nearest points connecting the two bodies */

--- a/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h
+++ b/moveit_core/collision_detection_bullet/include/moveit/collision_detection_bullet/bullet_integration/contact_checker_common.h
@@ -145,7 +145,7 @@ inline collision_detection::Contact* processResult(ContactTestData& cdata, colli
  *                units towards the center along its normal).
  * @param (input) shrinkClamp If positive, "shrink" is clamped to not exceed "shrinkClamp * innerRadius", where
  *                "innerRadius" is the minimum distance of a face to the center of the convex hull.
- * @return The number of faces. If less than zero an error occured when trying to create the convex hull
+ * @return The number of faces. If less than zero an error occurred when trying to create the convex hull
  */
 inline int createConvexHull(AlignedVector<Eigen::Vector3d>& vertices, std::vector<int>& faces,
                             const AlignedVector<Eigen::Vector3d>& input, double shrink = -1, double shrinkClamp = -1)

--- a/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v1/kinematics_cache/include/kinematics_cache/kinematics_cache.h
@@ -99,7 +99,7 @@ public:
    *  @param solver An instance of a kinematics solver
    *  @param kinematic_model An instance of a kinematic model
    *  @param opt Parameters needed for defining the cache workspace
-   *  @return False if any error occured during initialization
+   *  @return False if any error occurred during initialization
    */
   bool initialize(kinematics::KinematicsBaseConstPtr& solver,
                   const planning_models::RobotModelConstPtr& kinematic_model, const KinematicsCache::Options& opt);

--- a/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
+++ b/moveit_experimental/kinematics_cache/v2/kinematics_cache/include/moveit/kinematics_cache/kinematics_cache.h
@@ -99,7 +99,7 @@ public:
    *  @param solver An instance of a kinematics solver
    *  @param kinematic_model An instance of a kinematic model
    *  @param opt Parameters needed for defining the cache workspace
-   *  @return False if any error occured during initialization
+   *  @return False if any error occurred during initialization
    */
   bool initialize(kinematics::KinematicsBaseConstPtr& solver, const moveit::core::RobotModelConstPtr& kinematic_model,
                   const KinematicsCache::Options& opt);

--- a/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
+++ b/moveit_kinematics/srv_kinematics_plugin/src/srv_kinematics_plugin.cpp
@@ -324,7 +324,7 @@ bool SrvKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::Pose
   if (!moveit::core::robotStateMsgToRobotState(ik_srv.response.solution, *robot_state_))
   {
     ROS_ERROR_STREAM_NAMED("srv",
-                           "An error occured converting received robot state message into internal robot state.");
+                           "An error occurred converting received robot state message into internal robot state.");
     error_code.val = error_code.FAILURE;
     return false;
   }

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1909,9 +1909,8 @@ srdf::Model::Group* MoveItConfigData::findGroupByName(const std::string& name)
 
   // Check if subgroup was found
   if (searched_group == nullptr)  // not found
-    ROS_FATAL_STREAM("An internal error has occurred while searching for groups. Group '" << name
-                                                                                         << "' was not found "
-                                                                                            "in the SRDF.");
+    ROS_FATAL_STREAM("An internal error has occurred while searching for groups. Group '"
+                     << name << "' was not found in the SRDF.");
 
   return searched_group;
 }

--- a/moveit_setup_assistant/src/tools/moveit_config_data.cpp
+++ b/moveit_setup_assistant/src/tools/moveit_config_data.cpp
@@ -1814,7 +1814,7 @@ bool MoveItConfigData::inputSetupAssistantYAML(const std::string& file_path)
     ROS_ERROR_STREAM(e.what());
   }
 
-  return false;  // if it gets to this point an error has occured
+  return false;  // if it gets to this point an error has occurred
 }
 
 // ******************************************************************************************
@@ -1909,7 +1909,7 @@ srdf::Model::Group* MoveItConfigData::findGroupByName(const std::string& name)
 
   // Check if subgroup was found
   if (searched_group == nullptr)  // not found
-    ROS_FATAL_STREAM("An internal error has occured while searching for groups. Group '" << name
+    ROS_FATAL_STREAM("An internal error has occurred while searching for groups. Group '" << name
                                                                                          << "' was not found "
                                                                                             "in the SRDF.");
 

--- a/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/configuration_files_widget.cpp
@@ -1151,7 +1151,7 @@ bool ConfigurationFilesWidget::generatePackage()
     // Run the generate function
     if (!file->gen_func_(absolute_path))
     {
-      // Error occured
+      // Error occurred
       QMessageBox::critical(this, "Error Generating File",
                             QString("Failed to generate folder or file: '")
                                 .append(file->rel_path_.c_str())

--- a/moveit_setup_assistant/src/widgets/controllers_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/controllers_widget.cpp
@@ -777,7 +777,7 @@ void ControllersWidget::editSelected()
   }
   else
   {
-    QMessageBox::critical(this, "Error Loading", "An internal error has occured while loading.");
+    QMessageBox::critical(this, "Error Loading", "An internal error has occurred while loading.");
   }
 }
 

--- a/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/end_effectors_widget.cpp
@@ -415,7 +415,7 @@ srdf::Model::EndEffector* EndEffectorsWidget::findEffectorByName(const std::stri
   // Check if effector was found
   if (searched_group == nullptr)  // not found
   {
-    QMessageBox::critical(this, "Error Saving", "An internal error has occured while saving. Quitting.");
+    QMessageBox::critical(this, "Error Saving", "An internal error has occurred while saving. Quitting.");
     QApplication::quit();
   }
 

--- a/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/planning_groups_widget.cpp
@@ -484,7 +484,7 @@ void PlanningGroupsWidget::editSelected()
       loadGroupScreen(plan_group.group_);
       break;
     default:
-      QMessageBox::critical(this, "Error Loading", "An internal error has occured while loading.");
+      QMessageBox::critical(this, "Error Loading", "An internal error has occurred while loading.");
       return;
   }
   return_screen_ = 0;  // return to main screen directly

--- a/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/robot_poses_widget.cpp
@@ -823,7 +823,7 @@ SliderWidget::SliderWidget(QWidget* parent, const moveit::core::JointModel* join
   const std::vector<moveit_msgs::JointLimits>& limits = joint_model_->getVariableBoundsMsg();
   if (limits.empty())
   {
-    QMessageBox::critical(this, "Error Loading", "An internal error has occured while loading the joints");
+    QMessageBox::critical(this, "Error Loading", "An internal error has occurred while loading the joints");
     return;
   }
 

--- a/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/start_screen_widget.cpp
@@ -377,18 +377,18 @@ bool StartScreenWidget::loadExistingFiles()
 
   // Get the URDF path using the loaded .setup_assistant data and check it
   if (!createFullURDFPath())
-    return false;  // error occured
+    return false;  // error occurred
 
   // use xacro args from GUI
   config_data_->xacro_args_ = stack_path_->getArgs().toStdString();
 
   // Load the URDF
   if (!loadURDFFile(config_data_->urdf_path_, config_data_->xacro_args_))
-    return false;  // error occured
+    return false;  // error occurred
 
   // Get the SRDF path using the loaded .setup_assistant data and check it
   if (!createFullSRDFPath(config_data_->config_pkg_path_))
-    return false;  // error occured
+    return false;  // error occurred
 
   // Progress Indicator
   progress_bar_->setValue(50);
@@ -396,7 +396,7 @@ bool StartScreenWidget::loadExistingFiles()
 
   // Load the SRDF
   if (!loadSRDFFile(config_data_->srdf_path_, config_data_->xacro_args_))
-    return false;  // error occured
+    return false;  // error occurred
 
   // Progress Indicator
   progress_bar_->setValue(60);

--- a/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
+++ b/moveit_setup_assistant/src/widgets/virtual_joints_widget.cpp
@@ -369,7 +369,7 @@ srdf::Model::VirtualJoint* VirtualJointsWidget::findVJointByName(const std::stri
   // Check if vjoint was found
   if (searched_group == nullptr)  // not found
   {
-    QMessageBox::critical(this, "Error Saving", "An internal error has occured while saving. Quitting.");
+    QMessageBox::critical(this, "Error Saving", "An internal error has occurred while saving. Quitting.");
     QApplication::quit();
   }
 


### PR DESCRIPTION
Fixed 17 instances of the typo 'occured' → 'occurred' across 13 files.

(AI-assisted)